### PR TITLE
[Fix] Scrollspy primary heading bug

### DIFF
--- a/src/components/marketing/ZScrollSpy/ZScrollSpy.vue
+++ b/src/components/marketing/ZScrollSpy/ZScrollSpy.vue
@@ -59,7 +59,7 @@ export default Vue.extend({
       type: String,
       default: 'left',
       validator: (val: string) =>
-        Object.keys(HEADING_ALIGNMENT_CLASSES).some(alignment => alignment === val)
+        Object.keys(HEADING_ALIGNMENT_CLASSES).some((alignment) => alignment === val)
     }
   },
   data() {
@@ -86,7 +86,7 @@ export default Vue.extend({
     })
   },
   mounted() {
-    this.headingElements.forEach(headingElement => {
+    this.headingElements.forEach((headingElement) => {
       this.addAsHeadingToHeadingsMap(headingElement)
       this.observer.observe(headingElement)
     })


### PR DESCRIPTION
## Bug Definition
In the content, if `h1` is not present then the table of contents does not get formed. This is because `h1` is, by default, the primary heading tag name and should be at the highest level in the table of contents.

## Solution
Now, the primary heading tag name is not `h1` by default. If `h1` not found in all the headings, ScrollSpy automatically chooses `h2` as a primary heading tag name and forms the table of contents.