### PR TITLE
chore: update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@deepsourcelabs/zeal",
   "version": "0.2.2",
-  "repository": "https://github.com/deepsourcelabs/zeal",
+  "repository": "https://github.com/deepsourcelabs/bifrost",
   "main": "./dist/zeal.common.js",
   "private": true,
   "scripts": {


### PR DESCRIPTION
chore: update `package.json` post publish

The repository url was changed in https://github.com/deepsourcelabs/zeal/pull/63, this blocks publishing. This PR reverts the change