### PR TITLE
[PLT-1135]: Include a badge component to Zeal

### DIFF
--- a/src/components/ZBadge/ZBadge.stories.ts
+++ b/src/components/ZBadge/ZBadge.stories.ts
@@ -1,0 +1,84 @@
+import '../../assets/css/tailwind.css'
+import '../../assets/css/typography.css'
+import '../../assets/css/layout.css'
+import ZBadge from './ZBadge.vue'
+import ZButton from '@/components/ZButton'
+import ZAvatar from '@/components/ZAvatar'
+
+export default {
+  title: 'Badge',
+  component: ZBadge,
+  excludeStories: /.*Data$/
+}
+
+export const BasicBadge = () => ({
+  components: { ZBadge, ZButton },
+  template: `<div class='padded-container'>
+        <z-badge type="danger" :value="12">
+            <z-button color="primary">Likes</z-button>
+        </z-badge>
+    </div>`
+})
+
+export const BadgeWithDifferentTypes = () => ({
+  components: { ZBadge, ZButton },
+  template: `<div class='padded-container flex space-x-8'>
+        <z-badge type="success" value="new">
+            <z-button color="secondary">Likes</z-button>
+        </z-badge>
+         <z-badge type="warning" value="new">
+            <z-button color="secondary">Likes</z-button>
+        </z-badge>
+         <z-badge type="info" value="new">
+            <z-button color="secondary">Likes</z-button>
+        </z-badge>
+         <z-badge type="danger" value="new">
+            <z-button color="secondary">Likes</z-button>
+        </z-badge>
+    </div>`
+})
+
+export const BadgeWithMaxSize = () => ({
+  components: { ZBadge, ZButton },
+  template: `<div class='padded-container'>
+        <z-badge type="success" :value="150" :max="99">
+            <z-button color="secondary">Filter</z-button>
+        </z-badge>
+    </div>`
+})
+
+export const DotBadge = () => ({
+  components: { ZBadge, ZButton },
+  template: `<div class='padded-container'>
+        <z-badge type="success" is-dot>
+            <z-button color="secondary">Filter</z-button>
+        </z-badge>
+    </div>`
+})
+
+export const DotBadgeWithDifferentSizes = () => ({
+  components: { ZBadge, ZButton },
+  template: `<div class='padded-container flex space-x-8'>
+        <z-badge type="success" is-dot size="sm">
+            <z-button color="secondary">Filter</z-button>
+        </z-badge>
+        <z-badge type="success" is-dot size="md">
+            <z-button color="secondary">Filter</z-button>
+        </z-badge>
+        <z-badge type="success" is-dot size="lg">
+            <z-button color="secondary">Filter</z-button>
+        </z-badge>
+    </div>`
+})
+
+export const DotBadgeWithCustomPositioning = () => ({
+  components: { ZBadge, ZButton, ZAvatar },
+  template: `<div class='padded-container'>
+        <z-badge is-dot type="warning" size="md" position="right-2 top-1">
+            <z-avatar
+            user-name="Akshay Paliwal"
+            size="md"
+            ></z-avatar>
+        </z-badge>
+    </div>`
+})

--- a/src/components/ZBadge/ZBadge.vue
+++ b/src/components/ZBadge/ZBadge.vue
@@ -1,0 +1,94 @@
+<template>
+  <div class="relative inline-block z-badge">
+    <slot></slot>
+    <sup
+      v-show="!hidden && (content || content === 0 || isDot)"
+      v-text="content"
+      class="absolute inline-block text-xs text-center transform translate-x-full -translate-y-1/2 z-badge-content"
+      :class="[
+        getBgColor,
+        getSize,
+        getPosition,
+        `text-${textColor}`,
+        {
+          'p-0 rounded-full': isDot,
+          'px-2 leading-4 rounded-full': value
+        }
+      ]"
+    >
+    </sup>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  name: 'ZBadge',
+  components: {},
+  props: {
+    value: [String, Number],
+    max: Number,
+    isDot: Boolean,
+    hidden: Boolean,
+    size: {
+      type: String,
+      default: 'sm',
+      validator(val) {
+        return ['sm', 'md', 'lg'].indexOf(val) > -1
+      }
+    },
+    type: {
+      type: String,
+      default: 'default',
+      validator(val) {
+        return ['default', 'success', 'warning', 'info', 'danger'].indexOf(val) > -1
+      }
+    },
+    position: {
+      type: String
+    },
+    textColor: {
+      type: String,
+      default: 'vanilla-100'
+    }
+  },
+  computed: {
+    getBgColor() {
+      const colors: Record<string, string> = {
+        default: '',
+        success: 'juniper',
+        warning: 'honey',
+        info: 'aqua',
+        danger: 'cherry'
+      }
+      return `bg-${colors[this.type as string]}`
+    },
+    getSize() {
+      const sizes: Record<string, string> = {
+        sm: 'w-2 h-2',
+        md: 'w-2.5 h-2.5',
+        lg: 'w-3 h-3'
+      }
+      return this.isDot ? sizes[this.size as string] : ''
+    },
+    getPosition(): string {
+      if (this.position) return this.position as string
+      else {
+        if (this.value) return 'top-0 right-3'
+        if (this.isDot) return 'top-0 right-1'
+        return 'top-0'
+      }
+    },
+    content() {
+      if (this.isDot) return
+      const value = this.value,
+        max = this.max
+      if (typeof value === 'number' && typeof max === 'number') {
+        return max < value ? `${max}+` : value
+      }
+      return value
+    }
+  }
+})
+</script>

--- a/src/components/ZBadge/index.ts
+++ b/src/components/ZBadge/index.ts
@@ -1,0 +1,3 @@
+import ZBadge from './ZBadge.vue'
+
+export default ZBadge

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,7 @@ import ZMenuSection from './components/ZMenu/ZMenuSection'
 import ZMenuItem from './components/ZMenu/ZMenuItem'
 import ZSidebarMenu from './components/ZSidebarMenu/index'
 import ZSidebarItem from './components/ZSidebarItem/index'
+import ZBadge from './components/ZBadge/index'
 
 const components = [
   ZButton,
@@ -69,7 +70,8 @@ const components = [
   ZTabPane,
   ZSidebarMenu,
   ZSidebarItem,
-  ZRadioButton
+  ZRadioButton,
+  ZBadge
 ]
 
 const install = (Vue: any) => {
@@ -111,7 +113,8 @@ export default {
   ZMenuItem,
   ZSidebarMenu,
   ZSidebarItem,
-  ZRadioButton
+  ZRadioButton,
+  ZBadge
 }
 
 export { default as ZButton } from './components/ZButton/index'
@@ -147,3 +150,4 @@ export { default as ZTabPanes } from './components/ZTabs/ZTabPanes'
 export { default as ZTabPane } from './components/ZTabs/ZTabPane'
 export { default as ZSidebarMenu } from './components/ZSidebarMenu/index'
 export { default as ZSidebarItem } from './components/ZSidebarItem/index'
+export { default as ZBadge } from './components/ZBadge/index'

--- a/tests/unit/ZBadge.spec.ts
+++ b/tests/unit/ZBadge.spec.ts
@@ -1,0 +1,111 @@
+import ZBadge from '../../src/components/ZBadge'
+import ZButton from '../../src/components/ZButton'
+
+import { shallowMount, mount } from '@vue/test-utils'
+
+const slotData = {
+  default: 'Badge'
+}
+
+const BasicBadge = {
+  template: `<z-badge type="danger" :value="12">
+            <z-button color="primary">Likes</z-button>
+        </z-badge>`,
+  components: {
+    ZBadge,
+    ZButton
+  }
+}
+
+describe('Badge', () => {
+  it('renders a badge as a dot', () => {
+    const wrapper = shallowMount(ZBadge, {
+      slots: slotData,
+      propsData: {
+        isDot: true
+      }
+    })
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('renders a badge with content', () => {
+    const wrapper = mount(BasicBadge)
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('renders with state', () => {
+    expect(
+      shallowMount(ZBadge, {
+        propsData: {
+          state: 'success'
+        },
+        slots: slotData
+      }).html()
+    ).toMatchSnapshot()
+
+    expect(
+      shallowMount(ZBadge, {
+        propsData: {
+          state: 'danger'
+        },
+        slots: slotData
+      }).html()
+    ).toMatchSnapshot()
+
+    expect(
+      shallowMount(ZBadge, {
+        propsData: {
+          state: 'warning'
+        },
+        slots: slotData
+      }).html()
+    ).toMatchSnapshot()
+
+    expect(
+      shallowMount(ZBadge, {
+        propsData: {
+          state: 'info'
+        },
+        slots: slotData
+      }).html()
+    ).toMatchSnapshot()
+
+    expect(
+      shallowMount(ZBadge, {
+        propsData: {
+          state: 'default'
+        },
+        slots: slotData
+      }).html()
+    ).toMatchSnapshot()
+  })
+
+  it('renders with size', () => {
+    expect(
+      shallowMount(ZBadge, {
+        propsData: {
+          size: 'sm'
+        },
+        slots: slotData
+      }).html()
+    ).toMatchSnapshot()
+    expect(
+      shallowMount(ZBadge, {
+        propsData: {
+          size: 'md'
+        },
+        slots: slotData
+      }).html()
+    ).toMatchSnapshot()
+
+    expect(
+      shallowMount(ZBadge, {
+        propsData: {
+          size: 'lg'
+        },
+        slots: slotData
+      }).html()
+    ).toMatchSnapshot()
+  })
+})

--- a/tests/unit/__snapshots__/ZBadge.spec.ts.snap
+++ b/tests/unit/__snapshots__/ZBadge.spec.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Badge renders a badge as a dot 1`] = `<div class="relative inline-block z-badge">Badge <sup class="absolute inline-block text-xs text-center transform translate-x-full -translate-y-1/2 z-badge-content bg- w-2 h-2 top-0 right-1 text-vanilla-100 p-0 rounded-full"></sup></div>`;
+
+exports[`Badge renders a badge with content 1`] = `<div class="relative inline-block z-badge"><button href="#" type="button" class="inline-flex items-center font-medium border-transparent rounded-sm relative justify-center z-btn--primary false false px-6 h-8 text-xs sm:h-10 sm:text-base bg-juniper text-ink-400 hover:bg-light_juniper">Likes</button> <sup class="absolute inline-block text-xs text-center transform translate-x-full -translate-y-1/2 z-badge-content bg-cherry top-0 right-3 text-vanilla-100 px-2 leading-4 rounded-full">12</sup></div>`;
+
+exports[`Badge renders with size 1`] = `<div class="relative inline-block z-badge">Badge <sup class="absolute inline-block text-xs text-center transform translate-x-full -translate-y-1/2 z-badge-content bg- top-0 text-vanilla-100" style="display: none;"></sup></div>`;
+
+exports[`Badge renders with size 2`] = `<div class="relative inline-block z-badge">Badge <sup class="absolute inline-block text-xs text-center transform translate-x-full -translate-y-1/2 z-badge-content bg- top-0 text-vanilla-100" style="display: none;"></sup></div>`;
+
+exports[`Badge renders with size 3`] = `<div class="relative inline-block z-badge">Badge <sup class="absolute inline-block text-xs text-center transform translate-x-full -translate-y-1/2 z-badge-content bg- top-0 text-vanilla-100" style="display: none;"></sup></div>`;
+
+exports[`Badge renders with state 1`] = `<div class="relative inline-block z-badge" state="success">Badge <sup class="absolute inline-block text-xs text-center transform translate-x-full -translate-y-1/2 z-badge-content bg- top-0 text-vanilla-100" style="display: none;"></sup></div>`;
+
+exports[`Badge renders with state 2`] = `<div class="relative inline-block z-badge" state="danger">Badge <sup class="absolute inline-block text-xs text-center transform translate-x-full -translate-y-1/2 z-badge-content bg- top-0 text-vanilla-100" style="display: none;"></sup></div>`;
+
+exports[`Badge renders with state 3`] = `<div class="relative inline-block z-badge" state="warning">Badge <sup class="absolute inline-block text-xs text-center transform translate-x-full -translate-y-1/2 z-badge-content bg- top-0 text-vanilla-100" style="display: none;"></sup></div>`;
+
+exports[`Badge renders with state 4`] = `<div class="relative inline-block z-badge" state="info">Badge <sup class="absolute inline-block text-xs text-center transform translate-x-full -translate-y-1/2 z-badge-content bg- top-0 text-vanilla-100" style="display: none;"></sup></div>`;
+
+exports[`Badge renders with state 5`] = `<div class="relative inline-block z-badge" state="default">Badge <sup class="absolute inline-block text-xs text-center transform translate-x-full -translate-y-1/2 z-badge-content bg- top-0 text-vanilla-100" style="display: none;"></sup></div>`;


### PR DESCRIPTION
This PR adds a badge component to the Zeal library.

### Properties
1. `type`: `success`, `danger`, `warning`, `info`, **`default`**
2. `size`: `sm`, `md`, `lg`
3. `is-dot`: `true`, `false`
4. `position`: any tailwind class(especially left, right, top, bottom specs)
5. `value`: number/string
6. `max`: number
7. `text-color`: Colors from tailwind config

### Basic Usage
```vue
<z-badge type="danger" :value="12">
    <z-button color="primary">Likes</z-button>
 </z-badge>
```

### Dot Badge
```vue
<z-badge type="success" is-dot>
   <z-button color="secondary">Filter</z-button>
</z-badge>
```

![image](https://user-images.githubusercontent.com/73866406/106695560-dbe23400-6600-11eb-82ee-2e4e52d82e2d.png)

![image](https://user-images.githubusercontent.com/73866406/106695561-dd136100-6600-11eb-88af-09a59e496d76.png)


