### PR TITLE
Add min width in tailwind and add a click function

### DIFF
--- a/src/components/ZSidebarMenu/ZSidebarMenu.vue
+++ b/src/components/ZSidebarMenu/ZSidebarMenu.vue
@@ -40,7 +40,8 @@
     </div>
     <!-- Overlay -->
     <div
-      :class="{ 'absolute w-full h-screen bg-ink-400 opacity-50 left-0 top-0 z-20': isOpen }"
+      :class="{ 'fixed w-full h-screen bg-ink-400 opacity-50 left-0 top-0 z-20': isOpen }"
+      @click="closeModal()"
     ></div>
   </div>
 </template>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -345,6 +345,7 @@ module.exports = {
     }),
     minWidth: (theme) => ({
       0: '0',
+      '1/2': '50%',
       full: '100%',
       min: 'min-content',
       max: 'max-content',


### PR DESCRIPTION
This PR contains two changes

1.  Adds `minWidth: 50%` to the tailwind config
2. Add a click function to the Sidebar Overlay