### PR TITLE
[PLT-1207]: Add Accordions to Zeal with its respective stories and tests

### DIFF
--- a/src/components/ZAccordion/ZAccordion.stories.ts
+++ b/src/components/ZAccordion/ZAccordion.stories.ts
@@ -1,0 +1,262 @@
+import '../../assets/css/tailwind.css'
+import '../../assets/css/typography.css'
+import '../../assets/css/layout.css'
+import ZAccordion from './ZAccordion.vue'
+import ZAccordionItem from '@/components/ZAccordionItem/ZAccordionItem.vue'
+import ZIcon from '@/components/ZIcon/ZIcon.vue'
+import ZButton from '@/components/ZButton/ZButton.vue'
+import ZInput from '@/components/ZInput/ZInput.vue'
+
+export default {
+  title: 'Accordion',
+  component: ZAccordion,
+  excludeStories: /.*Data$/
+}
+
+export const DefaultAccordion = () => ({
+  components: { ZAccordion, ZAccordionItem },
+  template: `<div class='padded-container input-container'>
+        <z-accordion class="text-vanilla-100">
+          <z-accordion-item title="Consistency" class="p-4">
+            <div>Consistent with real life: in line with the process and logic of real life, and comply with languages and habits that the users are used to;</div>
+            <div>Consistent within interface: all elements should be consistent, such as: design style, icons and texts, position of elements, etc.</div>
+          </z-accordion-item>
+          <z-accordion-item title="Feedback" class="p-4">
+            <div>Consistent with real life: in line with the process and logic of real life, and comply with languages and habits that the users are used to;</div>
+            <div>Consistent within interface: all elements should be consistent, such as: design style, icons and texts, position of elements, etc.</div>
+          </z-accordion-item>
+          <z-accordion-item title="Efficiency" class="p-4">
+            <div>Consistent with real life: in line with the process and logic of real life, and comply with languages and habits that the users are used to;</div>
+            <div>Consistent within interface: all elements should be consistent, such as: design style, icons and texts, position of elements, etc.</div>
+          </z-accordion-item>
+        </z-accordion>
+    </div>`
+})
+
+export const AccordionWithBaseStyle = () => ({
+  components: { ZAccordion, ZAccordionItem },
+  template: `<div class='padded-container input-container'>
+        <z-accordion class="text-vanilla-100" :showBorders="true">
+          <z-accordion-item title="Consistency" class="p-4">
+            <div>Consistent with real life: in line with the process and logic of real life, and comply with languages and habits that the users are used to;</div>
+            <div>Consistent within interface: all elements should be consistent, such as: design style, icons and texts, position of elements, etc.</div>
+          </z-accordion-item>
+          <z-accordion-item title="Feedback" class="p-4">
+            <div>Consistent with real life: in line with the process and logic of real life, and comply with languages and habits that the users are used to;</div>
+            <div>Consistent within interface: all elements should be consistent, such as: design style, icons and texts, position of elements, etc.</div>
+          </z-accordion-item>
+          <z-accordion-item title="Efficiency" class="p-4">
+            <div>Consistent with real life: in line with the process and logic of real life, and comply with languages and habits that the users are used to;</div>
+            <div>Consistent within interface: all elements should be consistent, such as: design style, icons and texts, position of elements, etc.</div>
+          </z-accordion-item>
+        </z-accordion>
+    </div>`
+})
+
+export const AccordionWithOpenedCards = () => ({
+  components: { ZAccordion, ZAccordionItem },
+  template: `<div class='padded-container input-container'>
+        <z-accordion class="text-vanilla-100" :showBorders="true">
+          <z-accordion-item title="Consistency" :is-open="true" class="p-4">
+            <div>Consistent with real life: in line with the process and logic of real life, and comply with languages and habits that the users are used to;</div>
+            <div>Consistent within interface: all elements should be consistent, such as: design style, icons and texts, position of elements, etc.</div>
+          </z-accordion-item>
+          <z-accordion-item title="Feedback" class="p-4">
+            <div>Consistent with real life: in line with the process and logic of real life, and comply with languages and habits that the users are used to;</div>
+            <div>Consistent within interface: all elements should be consistent, such as: design style, icons and texts, position of elements, etc.</div>
+          </z-accordion-item>
+          <z-accordion-item title="Efficiency" class="p-4">
+            <div>Consistent with real life: in line with the process and logic of real life, and comply with languages and habits that the users are used to;</div>
+            <div>Consistent within interface: all elements should be consistent, such as: design style, icons and texts, position of elements, etc.</div>
+          </z-accordion-item>
+        </z-accordion>
+    </div>`
+})
+
+export const AccordionWithDisabledState = () => ({
+  components: { ZAccordion, ZAccordionItem },
+  template: `<div class='padded-container input-container'>
+        <z-accordion class="text-vanilla-100" :showBorders="true" :disabled="true">
+          <z-accordion-item title="Consistency" class="p-4">
+            <div>Consistent with real life: in line with the process and logic of real life, and comply with languages and habits that the users are used to;</div>
+            <div>Consistent within interface: all elements should be consistent, such as: design style, icons and texts, position of elements, etc.</div>
+          </z-accordion-item>
+          <z-accordion-item title="Feedback" class="p-4">
+            <div>Consistent with real life: in line with the process and logic of real life, and comply with languages and habits that the users are used to;</div>
+            <div>Consistent within interface: all elements should be consistent, such as: design style, icons and texts, position of elements, etc.</div>
+          </z-accordion-item>
+          <z-accordion-item title="Efficiency" class="p-4">
+            <div>Consistent with real life: in line with the process and logic of real life, and comply with languages and habits that the users are used to;</div>
+            <div>Consistent within interface: all elements should be consistent, such as: design style, icons and texts, position of elements, etc.</div>
+          </z-accordion-item>
+        </z-accordion>
+    </div>`
+})
+
+export const AccordionUsedInNavBar = () => ({
+  components: { ZAccordion, ZAccordionItem },
+  data() {
+    return {
+      links: ['Documentation', 'Discourse Form', 'Learning Center', 'Blog', 'Slack User Group']
+    }
+  },
+  template: `<div class='padded-container input-container'>
+        <z-accordion class="text-vanilla-100">
+          <z-accordion-item title="Resources" class="font-medium p-4">
+            <div class="flex flex-col text-sm space-y-4 py-3">
+              <a v-for="link in links" :key="link" href="#" class="hover:text-juniper transition-all duration-75 ease-in-out">{{link}}</a>
+            </div>
+          </z-accordion-item>
+        </z-accordion>
+    </div>`
+})
+
+export const AccordionUsedInHeader = () => ({
+  components: { ZAccordion, ZAccordionItem, ZIcon },
+  data() {
+    return {
+      openAccordion: false,
+      links: ['Documentation', 'Discourse Form', 'Learning Center', 'Blog', 'Slack User Group']
+    }
+  },
+  template: `<div class='padded-container flex items-center w-52'>
+        <z-accordion class="text-vanilla-100 w-full">
+          <z-accordion-item :is-open="openAccordion" class="p-4">
+            <template v-slot:title="{ open, toggleAccordion }">
+              <div class="flex items-center cursor-pointer w-full" @click="toggleAccordion()">
+                <span class="flex-1 font-medium text-slate">Resources</span>
+                <z-icon icon="chevron-right" 
+                    size="small" color="slate" 
+                    class="transform"
+                    :class="open ? 'animate-first-quarter-spin rotate-90' : 'animate-reverse-quarter-spin rotate-0'"></z-icon>
+              </div>
+            </template>
+            <div class="flex flex-col text-sm space-y-4 py-3">
+              <a v-for="link in links" :key="link" href="#" class="hover:text-juniper transition-all duration-75 ease-in-out">{{link}}</a>
+            </div>
+          </z-accordion-item>
+        </z-accordion>
+    </div>`
+})
+
+export const ListLikeAccordion = () => ({
+  components: { ZAccordion, ZAccordionItem, ZIcon },
+  data() {
+    return {
+      openAccordion: false,
+      links: ['Documentation', 'Discourse Form', 'Learning Center', 'Blog', 'Slack User Group']
+    }
+  },
+  template: `<div class='padded-container flex items-center w-52'>
+        <z-accordion class="text-vanilla-100 w-full">
+          <z-accordion-item :is-open="openAccordion" :is-list="true" title="List Items" class="p-4">
+            <div class="flex flex-col text-sm space-y-4 py-3">
+              <a v-for="link in links" :key="link" href="#" class="hover:text-juniper transition-all duration-75 ease-in-out">{{link}}</a>
+            </div>
+          </z-accordion-item>
+        </z-accordion>
+    </div>`
+})
+
+export const WebNextFooter = () => ({
+  components: { ZAccordion, ZAccordionItem, ZIcon, ZButton, ZInput },
+  data() {
+    return {
+      openAccordion: false,
+      name: '',
+      product: ['Autofix', 'Code formatters', 'Pricing', 'Security'],
+      languages: ['For Python', 'For Go', 'For Ruby', 'For JavaScript'],
+      resources: ['Documentation', 'Blog', 'Changelog', 'Slack user group'],
+      company: [
+        'About',
+        'Customers',
+        'Jobs',
+        'Privacy Policy',
+        'Terms of Service',
+        'Press Enquiries',
+        'Brand Assets'
+      ]
+    }
+  },
+  computed: {
+    isMobile() {
+      return window.innerWidth < 768
+    }
+  },
+  template: `<div class="h-screen w-full-screen">
+        <div class="prose prose-md max-w-none p-20">
+        <h1 v-for="i in 8">Some random heading to grab attention</h1>
+        </div>
+        <footer class="w-full p-12 flex flex-col md:space-y-0 space-y-2 md:grid grid-rows-footer grid-cols-footer gap-x-8 gap-y-4 bg-transparent text-vanilla-100 border-t border-ink-200 min-h-102 bg-gradient-dark_dawn animate-gradient bg-400%">
+            <div class="flex row-start-1 row-end-1 col-start-1 col-end-1">
+                <img class="max-w-none h-8" src="https://i.imgur.com/zKLLWIr.png"/>
+            </div>
+            <z-accordion-item :is-list="!isMobile" title="Product" class="row-start-1 row-end-1 col-start-2 col-end-2 flex flex-col px-0 py-0 space-y-2 md:space-y-6 text-vanilla-400 tracking-wide uppercase">
+              <div class="flex flex-col space-y-2">
+                <a v-for="item in product" :key="item" href="#" class="hover:text-juniper transition-all duration-75 ease-in-out flex flex-col space-y-4 text-vanilla-300 capitalize">
+                    {{item}}
+                </a>
+              </div>
+            </z-accordion-item>
+            <z-accordion-item :is-list="!isMobile" title="languages" class="row-start-1 row-end-1 col-start-3 col-end-3 flex flex-col px-0 py-0  space-y-2 md:space-y-6 text-vanilla-400 tracking-wide uppercase">
+              <div class="flex flex-col space-y-2">
+                <a v-for="language in languages" :key="language" href="#" class="hover:text-juniper transition-all duration-75 ease-in-out flex flex-col space-y-4 text-vanilla-300 capitalize">
+                    {{language}}
+                </a>
+              </div>
+            </z-accordion-item>
+            <z-accordion-item :is-list="!isMobile" title="resources" class="row-start-1 row-end-1 col-start-4 col-end-4 flex flex-col px-0 py-0  space-y-2 md:space-y-6 text-vanilla-400 tracking-wide uppercase">
+              <div class="flex flex-col space-y-2">
+                <a v-for="item in resources" :key="item" href="#" class="hover:text-juniper transition-all duration-75 ease-in-out flex flex-col space-y-4 text-vanilla-300 capitalize">
+                    {{item}}
+                </a>
+              </div>
+            </z-accordion-item>
+            <z-accordion-item :is-list="!isMobile" title="company" class="row-start-1 row-end-1 col-start-5 col-end-5 flex flex-col px-0 py-0  space-y-2 md:space-y-6 text-vanilla-400 tracking-wide uppercase">
+              <div class="flex flex-col space-y-2">
+                <a v-for="item in company" :key="item" href="#" class="hover:text-juniper transition-all duration-75 ease-in-out flex flex-col space-y-4 text-vanilla-300 capitalize">
+                    {{item}}
+                </a>
+              </div>
+            </z-accordion-item>
+            <div class="row-start-1 row-end-1 col-start-6 col-end-6 flex flex-col space-y-6 text-vanilla-400 text-sm">
+                <div class="font-medium uppercase tracking-wide hidden md:block">Social Media</div>
+                <div class="flex flex-col-reverse md:flex-col gap-y-3 md:gap-y-16">
+                  <div class="flex flex-col space-y-4 items-center md:items-start">
+                    <div class="text-vanilla-300 hidden md:block">Follow us on social media to stay updated.</div>
+                    <div class="flex space-x-3">
+                        <z-icon size="medium" icon="dribbble" color="vanilla-300"></z-icon>
+                        <z-icon size="medium" icon="dribbble" color="vanilla-300"></z-icon>
+                        <z-icon size="medium" icon="dribbble" color="vanilla-300"></z-icon>
+                    </div>
+                  </div>
+                  <div class="flex flex-col space-y-2">
+                    <div class="uppercase">Sign up for the newsletter</div>
+                    <z-input v-model="name" backgroundColor="transparent">
+                      <template slot="right">
+                        <z-button color="primary" icon="chevron-right" iconSize="medium" iconColor="ink-400"></z-button>
+                      </template>
+                    </z-input>
+                  </div>
+                </div>
+            </div>
+            <div class="block md:hidden w-full h-px bg-slate"></div>
+            <div class="row-start-1 row-end-1 col-start-7 col-end-7 text-sm text-vanilla-400">
+                <div class="flex justify-center flex-row space-x-2 md:space-x-0 md:flex-col space-y-0 md:space-y-2">
+                    <div v-for="i in 2" :key="i" class="flex flex-col md:grid grid-rows-3 grid-cols-3 gap-x-4 p-2 md:p-2.5 tracking-wide bg-ink-300 rounded-sm w-auto md:w-full h-auto md:h-20 flex items-center">
+                        <img class="max-w-none row-span-3" src="https://i.imgur.com/JBKMaq5.png"/>
+                        <span class="uppercase font-medium col-span-2 text-vanilla-100">GDPR</span>
+                        <span class="row-span-2 col-span-2 tracking-normal">compliant</span>
+                    </div>
+                </div>
+            </div>
+            <span class="order-last self-center row-start-2 row-end-2 col-start-1 col-end-4 self-end text-left text-vanilla-400 text-xs md:text-sm">
+                © 2020, DeepSource Corp. All rights reserved.
+            </span>
+            <span class="row-start-2 self-center row-end-2 col-start-6 col-end-8 self-end justify-self-end text-vanilla-400 text-sm flex space-x-2 items-center">
+                Backed by 
+                <img class="ml-3 max-w-none" src="https://i.imgur.com/lnlRvjx.png"/>
+            </span>
+        </footer>
+    </div>`
+})

--- a/src/components/ZAccordion/ZAccordion.vue
+++ b/src/components/ZAccordion/ZAccordion.vue
@@ -1,0 +1,36 @@
+<template>
+  <div>
+    <slot></slot>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ZAccordion',
+  components: {},
+  props: {
+    defaultStyle: {
+      type: Boolean,
+      default: false
+    },
+    disabled: {
+      type: Boolean,
+      default: false
+    },
+    allowMultiple: {
+      type: Boolean,
+      default: true
+    },
+    showBorders: {
+      type: Boolean,
+      default: false
+    }
+  },
+  data() {
+    return {
+      accordionItems: []
+    }
+  },
+  computed: {}
+}
+</script>

--- a/src/components/ZAccordion/index.ts
+++ b/src/components/ZAccordion/index.ts
@@ -1,0 +1,3 @@
+import ZAccordion from './ZAccordion.vue'
+
+export default ZAccordion

--- a/src/components/ZAccordionItem/ZAccordionItem.vue
+++ b/src/components/ZAccordionItem/ZAccordionItem.vue
@@ -1,0 +1,94 @@
+<template>
+  <div
+    class="z-accordion-item"
+    :class="{
+      'border-ink-200 border-t border-b first:border-0 last:border-0 hover:bg-ink-300': this
+        .showBorders,
+      'text-slate': this.isDisabled
+    }"
+  >
+    <slot name="title" :open="open" :toggleAccordion="toggleAccordion">
+      <div
+        class="flex items-center transition-all duration-700 ease-in-out group"
+        @click="toggleAccordion()"
+        :class="{
+          'cursor-not-allowed': this.isDisabled,
+          'cursor-pointer': !this.isDisabled && !this.isList
+        }"
+      >
+        <span class="flex-1 font-medium text-vanilla-200">{{ title }}</span>
+        <z-icon
+          icon="chevron-right"
+          color="slate"
+          class="transform transition-all duration-DEFAULT ease-in-out group"
+          :class="[
+            accordionHeaderAnimations,
+            {
+              'text-vanilla-200 rotate-90': this.open,
+              'text-slate': this.isDisabled,
+              'group-hover:text-vanilla-200': !this.isDisabled,
+              hidden: this.isList
+            }
+          ]"
+        ></z-icon>
+      </div>
+    </slot>
+    <div
+      class="overflow-scroll transition-max-height duration-300 ease-in-out text-sm leading-6"
+      :class="{
+        'max-h-52': this.open,
+        'max-h-0': !this.open,
+        'max-h-full': this.isList
+      }"
+    >
+      <div class="py-2">
+        <slot></slot>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import ZIcon from '@/components/ZIcon'
+export default {
+  name: 'ZAccordionItem',
+  components: {
+    ZIcon
+  },
+  props: {
+    title: {
+      type: String
+    },
+    isOpen: {
+      type: Boolean,
+      default: false
+    },
+    icon: {
+      type: String,
+      default: 'down'
+    },
+    isList: {
+      type: Boolean,
+      default: false
+    }
+  },
+  data() {
+    return {
+      open: this.isOpen,
+      accordionHeaderAnimations: '',
+      isDisabled: this.$parent.disabled,
+      showBorders: this.$parent.showBorders
+    }
+  },
+  methods: {
+    toggleAccordion() {
+      if (this.isList) return
+      this.open = !this.open
+      this.accordionHeaderAnimations = this.open
+        ? 'animate-first-quarter-spin rotate-90'
+        : 'animate-reverse-quarter-spin rotate-0'
+      this.$emit('isOpen', this.open)
+    }
+  }
+}
+</script>

--- a/src/components/ZAccordionItem/index.ts
+++ b/src/components/ZAccordionItem/index.ts
@@ -1,0 +1,3 @@
+import ZAccordionItem from './ZAccordionItem.vue'
+
+export default ZAccordionItem

--- a/src/components/ZButton/ZButton.vue
+++ b/src/components/ZButton/ZButton.vue
@@ -11,8 +11,8 @@
       defaultClasses,
       `${color && `z-btn--${color}`}`,
       `${this.fullWidth !== false && 'w-full inline-block'}`,
-      `${this.isButtonDisabled && 'opacity-80 cursor-not-allowed'}`,
-      ((isLink || icon) && 'p-0') || 'px-6',
+      `${this.isButtonDisabled && 'opacity-50 cursor-not-allowed'}`,
+      ((isLink || icon) && 'p-0') || spacing,
       isLink || icon ? '' : sizeClasses,
       `${stylesBasedOnColor}`
     ]"
@@ -77,6 +77,10 @@ export default Vue.extend({
     hoverOpacity: {
       type: String,
       default: '50'
+    },
+    spacing: {
+      type: String,
+      default: 'px-6'
     }
   },
   data() {

--- a/src/components/ZMenu/ZMenu.vue
+++ b/src/components/ZMenu/ZMenu.vue
@@ -1,7 +1,7 @@
 <template>
   <span class="relative z-menu">
     <button v-on:click="toggle" class="outline-none focus:outline-none" ref="menu-trigger">
-      <slot name="trigger"></slot>
+      <slot name="trigger" :toggle="toggle" :isOpen="isOpen"></slot>
     </button>
     <transition
       enter-active-class="animate-slide-bottom-enter-active sm:animate-none sm:transition-all sm:duration-75 sm:ease-out-quad"
@@ -31,9 +31,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import outsideClickDirective from '../../directives/outside-click'
-
 Vue.directive('outside-click', outsideClickDirective)
-
 export default Vue.extend({
   name: 'ZMenu',
   props: {
@@ -53,6 +51,10 @@ export default Vue.extend({
     },
     width: {
       type: String
+    },
+    collapseOnMobile: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
@@ -84,7 +86,6 @@ export default Vue.extend({
         base: `py-1 text-sm w-full sm:w-${this.width || '64'} mt-5 sm:mt-2`,
         large: `py-2 text-base w-full sm:w-${this.width || '72'} mt-5 sm:mt-4`
       }
-
       return sizes[this.size || 'base']
     }
   }

--- a/src/components/ZNavBar/ZNavBar.stories.ts
+++ b/src/components/ZNavBar/ZNavBar.stories.ts
@@ -1,0 +1,230 @@
+import '../../assets/css/tailwind.css'
+import '../../assets/css/typography.css'
+import '../../assets/css/layout.css'
+import ZNavBar from './ZNavBar.vue'
+import ZButton from '../../components/ZButton/ZButton.vue'
+import ZIcon from '../../components/ZIcon/ZIcon.vue'
+import ZDivider from '../../components/ZDivider/ZDivider.vue'
+import ZList from '../../components/ZList/ZList.vue'
+import ZListItem from '../../components/ZListItem/ZListItem.vue'
+import ZMenu from '../../components/ZMenu/ZMenu.vue'
+import ZMenuItem from '../../components/ZMenu/ZMenuItem/ZMenuItem.vue'
+import ZMenuSection from '../../components/ZMenu/ZMenuItem/ZMenuItem.vue'
+
+export default {
+  title: 'NavBar',
+  component: ZNavBar,
+  excludeStories: /.*Data$/
+}
+
+export const Horizontal = () => ({
+  components: {
+    ZNavBar,
+    ZButton,
+    ZMenuItem,
+    ZMenu,
+    ZList,
+    ZListItem,
+    ZMenuSection,
+    ZIcon,
+    ZDivider
+  },
+  data() {
+    return {
+      resources: ['Documentation', 'Discourse forum', 'Learning Center', 'Blog', 'Slack User Group']
+    }
+  },
+  template: `<div class="bg-gradient-galaxy h-screen w-full-screen">
+                <z-nav-bar class="text-vanilla-100">
+                    <template slot="brand">
+                        <img class="h-4 sm:h-5 lg:h-7 max-w-none" src="https://assets.deepsource.io/fc583c0/images/logo-wordmark-white.svg"/>
+                    </template>
+                    <template slot="links">
+                        <z-menu width="auto">
+                            <template v-slot:trigger="{ isOpen, toggle }">
+                                <span class="block px-4 py-2 hover:bg-ink-300 rounded-sm"
+                                    :class="{
+                                       'bg-ink-300': isOpen,
+                                       'bg-transparent': !isOpen
+                                    }">Product</span>
+                            </template>
+                            <template slot="body">
+                                <div class="flex w-full space-x-4">
+                                    <z-list class="text-vanilla-400 text-sm lg:text-base space-y-3 w-auto lg:w-32 uppercase p-4 border-b border-ink-200 lg:border-0" title="Integrations">
+                                        <div class="flex flex-col space-y-4 text-vanilla-100 capitalize">
+                                            <z-list-item v-for="i in 3" :key="i" as="a" icon="gitlab" iconSize="medium" class="text-xs lg:text-sm flex cursor-pointer items-end space-x-2">
+                                                GitHub
+                                            </z-list-item>
+                                        </div>
+                                    </z-list>
+                                    <div class="h-auto w-px bg-slate"></div>
+                                    <z-list class="text-vanilla-400 text-sm lg:text-base space-y-3 w-auto lg:w-72 uppercase p-4 border-b border-ink-200 lg:border-0" title="Languages">
+                                        <div class="flex flex-col flex-nowrap lg:flex-row lg:flex-wrap space-x-0 space-y-4 lg:gap-x-3 lg:gap-y-3 lg:space-x-0 lg:space-y-0 text-vanilla-100 capitalize">
+                                            <z-list-item v-for="i in 10" :key="i" class="cursor-pointer" zStyle="w-full flex items-center space-x-2">
+                                                <img src="https://i.imgur.com/6r5cdUd.png" class="h-4 lg:h-10" />
+                                                <a class="text-xs lg:text-sm flex lg:hidden hover:text-juniper transition-all duration-300 ease-in-out">JavaScript</a>    
+                                            </z-list-item>
+                                        </div>
+                                    </z-list>
+                                </div>
+                            </template>
+                        </z-menu>
+                        <z-menu :collapseOnMobile="true">
+                            <template v-slot:trigger="{ isOpen, toggle }">
+                                <span class="block px-4 py-2 hover:bg-ink-300 rounded-sm"
+                                        :class="{
+                                            'bg-ink-300': isOpen,
+                                            'bg-transparent': !isOpen
+                                        }">Resources</span>
+                            </template>
+                            <template slot="body">
+                                <z-menu-item v-for="item in resources" :key="item">
+                                    <a class="text-xs lg:text-sm text-vanilla-400 lg:text-vanilla-100 inline-block cursor-pointer py-1 lg:hover:text-vanilla-100 hover:text-juniper transition-all duration-300 ease-in-out">{{item}}</a>    
+                                </z-menu-item>
+                            </template>
+                        </z-menu>
+                        <a class="flex px-4 py-2 hover:bg-ink-300 justify-start lg:justify-center border-b border-ink-200 lg:border-0" href="https://deepsource.io/">Enterprise</a>
+                        <a class="flex px-4 py-2 hover:bg-ink-300 border-b border-ink-200 lg:border-0" href="https://deepsource.io/pricing">Pricing</a>
+                    </template>
+                    <template slot="cta">
+                        <z-button color="link" type="link" class="text-xs sm:text-sm lg:text-base">Log in</z-button>
+                        <z-button color="primary" size="none" spacing="px-4 lg:px-6" class="text-xxs sm:text-xs lg:text-sm h-6 sm:h-8">Sign up</z-button>
+                    </template>
+                </z-nav-bar>
+    <div class="prose prose-sm sm:prose sm:max-w-none mx-auto px-10 py-16">
+    <h1 id="this-is-main">Just to show off main heading</h1>
+    <p class="lead">Until now, trying to style an article, document, or blog post with Tailwind has been a tedious task that required a keen eye for typography and a lot of complex custom CSS.</p>
+    <p>By default, Tailwind removes all of the default browser styling from paragraphs, headings, lists and more. This ends up being really useful for building application UIs because you spend less time undoing user-agent styles, but when you <em>really are</em> just trying to style some content that came from a rich-text editor in a CMS or a markdown file, it can be surprising and unintuitive.</p>
+    <p>We get lots of complaints about it actually, with people regularly asking us things like:</p>
+    <blockquote>
+    <p>Why is Tailwind removing the default styles on my <code>h1</code> elements? How do I disable this? What do you mean I lose all the other base styles too?</p>
+    </blockquote>
+    <p>We hear you, but we're not convinced that simply disabling our base styles is what you really want. You don't want to have to remove annoying margins every time you use a <code>p</code> element in a piece of your dashboard UI. And I doubt you really want your blog posts to use the user-agent styles either — you want them to look <em>awesome</em>, not awful.</p>
+    <p>The <code>@tailwindcss/typography</code> plugin is our attempt to give you what you <em>actually</em> want, without any of the downsides of doing something stupid like disabling our base styles.</p>
+    <p>It adds a new <code>prose</code> class that you can slap on any block of vanilla HTML content and turn it into a beautiful, well-formatted document:</p>
+    <p>For more information about how to use the plugin and the features it includes, <a href="https://github.com/tailwindcss/typography/blob/master/README.md">read the documentation</a>.</p>
+    <hr>
+    <h2 id="what-to-expect-from-here">What to expect from here on out</h2>
+    <p>What follows from here is just a bunch of absolute nonsense I've written to dogfood the plugin itself. It includes every sensible typographic element I could think of, like <strong>bold text</strong>, unordered lists, ordered lists, code blocks, block quotes, <em>and even italics</em>.</p>
+    <p>It's important to cover all of these use cases for a few reasons:</p>
+    <ol>
+    <li>We want everything to look good out of the box.</li>
+    <li>Really just the first reason, that's the whole point of the plugin.</li>
+    <li>Here's a third pretend reason though a list with three items looks more realistic than a list with two items.</li>
+    </ol>
+    <p>Now we're going to try out another header style.</p>
+    <h3 id="typography-should-be-easy">Typography should be easy</h3>
+    <p>So that's a header for you — with any luck if we've done our job correctly that will look pretty reasonable.</p>
+    <p>Something a wise person once told me about typography is:</p>
+    <blockquote>
+    <p>Typography is pretty important if you don't want your stuff to look like trash. Make it good then it won't be bad.</p>
+    </blockquote>
+    <p>It's probably important that images look okay here by default as well:</p>
+    <figure>
+    <img src="https://images.unsplash.com/photo-1556740758-90de374c12ad?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=crop&amp;w=1000&amp;q=80" alt="">  
+    <figcaption>Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.</figcaption>
+    </figure>
+    <p>Now I'm going to show you an example of an unordered list to make sure that looks good, too:</p>
+    <ul>
+    <li>So here is the first item in this list.</li>
+    <li>In this example we're keeping the items short.</li>
+    <li>Later, we'll use longer, more complex list items.</li>
+    </ul>
+    <p>And that's the end of this section.</p>
+    <h2 id="what-if-we-stack-headings">What if we stack headings?</h2>
+    <h3 id="we-should-make-sure">We should make sure that looks good, too.</h3>
+    <p>Sometimes you have headings directly underneath each other. In those cases you often have to undo the top margin on the second heading because it usually looks better for the headings to be closer together than a paragraph followed by a heading should be.</p>
+    <h3 id="when-heading-comes-after-paragraph">When a heading comes after a paragraph …</h3>
+    <p>When a heading comes after a paragraph, we need a bit more space, like I already mentioned above. Now let's see what a more complex list would look like.</p>
+    <ul>
+    <li>
+        <p><strong>I often do this thing where list items have headings.</strong></p>
+        <p>For some reason I think this looks cool which is unfortunate because it's pretty annoying to get the styles right.</p>
+        <p>I often have two or three paragraphs in these list items, too, so the hard part is getting the spacing between the paragraphs, list item heading, and separate list items to all make sense. Pretty tough honestly, you could make a strong argument that you just shouldn't write this way.</p>
+    </li>
+    <li>
+        <p><strong>Since this is a list, I need at least two items.</strong></p>
+        <p>I explained what I'm doing already in the previous list item, but a list wouldn't be a list if it only had one item, and we really want this to look realistic. That's why I've added this second list item so I actually have something to look at when writing the styles.</p>
+    </li>
+    <li>
+        <p><strong>It's not a bad idea to add a third item either.</strong></p>
+        <p>I think it probably would've been fine to just use two items but three is definitely not worse, and since I seem to be having no trouble making up arbitrary things to type, I might as well include it.</p>
+    </li>
+    </ul>
+    <p>After this sort of list I usually have a closing statement or paragraph, because it kinda looks weird jumping right to a heading.</p>
+    <hr>
+    <h1 id="here-is-another-h1">Here is another h1 out of nowhere</h1>
+    <h2 id="code-should-look-okay">Code should look okay by default.</h2>
+    <p>I think most people are going to use <a href="https://highlightjs.org/">highlight.js</a> or <a href="https://prismjs.com/">Prism</a> or something if they want to style their code blocks but it wouldn't hurt to make them look <em>okay</em> out of the box, even with no syntax highlighting.</p>
+    <p>Here's what a default <code>tailwind.config.js</code> file looks like at the time of writing:</p>
+    <p>Hopefully that looks good enough to you.</p>
+    <h3 id="what-about-nested-lists">What about nested lists?</h3>
+    <p>Nested lists basically always look bad which is why editors like Medium don't even let you do it, but I guess since some of you goofballs are going to do it we have to carry the burden of at least making it work.</p>
+    <ol>
+    <li><strong>Nested lists are rarely a good idea.</strong>
+        <ul>
+        <li>You might feel like you are being really "organized" or something but you are just creating a gross shape on the screen that is hard to read.</li>
+        <li>Nested navigation in UIs is a bad idea too, keep things as flat as possible.</li>
+        <li>Nesting tons of folders in your source code is also not helpful.</li>
+        </ul>
+    </li>
+    <li><strong>Since we need to have more items, here's another one.</strong>
+    <ul>
+    <li>I'm not sure if we'll bother styling more than two levels deep.</li>
+    <li>Two is already too much, three is guaranteed to be a bad idea.</li>
+    <li>If you nest four levels deep you belong in prison.</li>
+    </ul>
+    </li>
+    <li><strong>Two items isn't really a list, three is good though.</strong>
+    <ul>
+    <li>Again please don't nest lists if you want people to actually read your content.</li>
+    <li>Nobody wants to look at this.</li>
+    <li>I'm upset that we even have to bother styling this.</li>
+    </ul>
+    </li>
+    </ol>
+    <p>The most annoying thing about lists in Markdown is that <code>&lt;li&gt;</code> elements aren't given a child <code>&lt;p&gt;</code> tag unless there are multiple paragraphs in the list item. That means I have to worry about styling that annoying situation too.</p>
+    <ul>
+    <li>
+    <p><strong>For example, here's another nested list.</strong></p>
+    <p>But this time with a second paragraph.</p>
+    <ul>
+    <li>These list items won't have <code>&lt;p&gt;</code> tags</li>
+    <li>Because they are only one line each</li>
+    </ul>
+    </li>
+    <li>
+    <p><strong>But in this second top-level list item, they will.</strong></p>
+    <p>This is especially annoying because of the spacing on this paragraph.</p>
+    <ul>
+    <li>
+        <p>As you can see here, because I've added a second line, this list item now has a <code>&lt;p&gt;</code> tag.</p>
+        <p>This is the second line I'm talking about by the way.</p>
+    </li>
+    <li>
+    <p>Finally here's another list item so it's more like a list.</p>
+    </li>
+    </ul>
+    </li>
+    <li>
+        <p>A closing list item, but with no nested list, because why not?</p>
+    </li>
+    </ul>
+    <p>And finally a sentence to close off this section.</p>
+    <h2 id="there-are-other-elements">There are other elements we need to style</h2>
+    <p>I almost forgot to mention links, like <a href="https://tailwindcss.com">this link to the Tailwind CSS website</a>. We almost made them blue but that's so yesterday, so we went with dark gray, feels edgier.</p>
+    <p>We even included table styles, check it out:</p>
+    <h3 id="sometimes-i-even-use">Sometimes I even use <code>code</code> in headings</h3>
+    <p>Even though it's probably a bad idea, and historically I've had a hard time making it look good. This <em>"wrap the code blocks in backticks"</em> trick works pretty well though really.</p>
+    <p>Another thing I've done in the past is put a <code>code</code> tag inside of a link, like if I wanted to tell you about the <a href="https://github.com/tailwindcss/docs"><code>tailwindcss/docs</code></a> repository. I don't love that there is an underline below the backticks but it is absolutely not worth the madness it would require to avoid it.</p>
+    <h4>We haven't used an <code>h4</code> yet</h4>
+    <p>But now we have. Please don't use <code>h5</code> or <code>h6</code> in your content, Medium only supports two heading levels for a reason, you animals. I honestly considered using a <code>before</code> pseudo-element to scream at you if you use an <code>h5</code> or <code>h6</code>.</p>
+    <p>We don't style them at all out of the box because <code>h4</code> elements are already so small that they are the same size as the body copy. What are we supposed to do with an <code>h5</code>, make it <em>smaller</em> than the body copy? No thanks.</p>
+    <h3 id="we-still-need-to-think">We still need to think about stacked headings though.</h3>
+    <h4>Let's make sure we don't screw that up with <code>h4</code> elements, either.</h4>
+    <p>Phew, with any luck we have styled the headings above this text and they look pretty good.</p>
+    <p>Let's add a closing paragraph here so things end with a decently sized block of text. I can't explain why I want things to end that way but I have to assume it's because I think things will look weird or unbalanced if there is a heading too close to the end of the document.</p>
+    <p>What I've written here is probably long enough, but adding this final sentence can't hurt.</p>
+    </div>
+    </div>`
+})

--- a/src/components/ZNavBar/ZNavBar.vue
+++ b/src/components/ZNavBar/ZNavBar.vue
@@ -1,0 +1,169 @@
+<script>
+import ZIcon from '@/components/ZIcon/ZIcon.vue'
+import ZAccordionItem from '@/components/ZAccordionItem/ZAccordionItem.vue'
+export default {
+  name: 'ZNavBar',
+  components: {
+    ZIcon,
+    ZAccordionItem
+  },
+  props: {
+    maxWidth: {
+      type: String
+    },
+    hideLinksOnScroll: {
+      type: Boolean,
+      default: false
+    }
+  },
+  data() {
+    return {
+      isOpen: false,
+      isScrolling: false,
+      isUserOnTop: true,
+      hideOnScroll: ''
+    }
+  },
+  mounted() {
+    document.addEventListener('scroll', this.handleScroll)
+  },
+  beforeDestroy() {
+    document.removeEventListener('scroll', this.handleScroll)
+  },
+  watch: {
+    isScrolling() {
+      this.scrollTimer = setTimeout(() => {
+        this.isScrolling = false
+      }, 1500)
+    }
+  },
+  computed: {
+    headerWrapperStyle() {
+      return `${this.isScrolling && 'lg:backdrop-blur lg:bg-opacity-25'} ${
+        this.isUserOnTop && 'lg:border-0'
+      } 
+        fixed left-0 top-0 flex z-1000 justify-center w-full max-w-full bg-ink-400 border-b border-ink-200 min-h-16`
+    },
+    mobHeaderStyle() {
+      return `${this.isOpen ? 'right-0' : '-right-full'} 
+              overflow-y-scroll lg:-right-full w-full h-screen absolute flex flex-col space-y-2 transition-all duration-700 ease-in-out top-0 bg-ink-300 flex flex-col`
+    },
+    linkSlotStyle() {
+      return `${this.hideOnScroll} 
+              second hidden lg:flex flex-1 items-center justify-center space-x-4 w-full transition-all duration-300 ease-in-out`
+    }
+  },
+  methods: {
+    toPascal(word) {
+      // https://stackoverflow.com/a/53952925
+      return `${word}`
+        .replace(new RegExp(/[-_]+/, 'g'), ' ')
+        .replace(new RegExp(/[^\w\s]/, 'g'), '')
+        .replace(
+          new RegExp(/\s+(.)(\w+)/, 'g'),
+          ($1, $2, $3) => `${$2.toUpperCase() + $3.toLowerCase()}`
+        )
+        .replace(new RegExp(/\s/, 'g'), '')
+        .replace(new RegExp(/\w/), (s) => s.toUpperCase())
+    },
+    toggleModal() {
+      this.isOpen = !this.isOpen
+    },
+    handleScroll() {
+      this.isScrolling = true
+      this.isUserOnTop = Boolean(!(window.scrollY > 50))
+      this.hideOnScroll =
+        window.scrollY > 50 && this.hideLinksOnScroll ? 'lg:opacity-0' : 'lg:opacity-1'
+    },
+    getComponent(parent, name, list = []) {
+      parent.forEach((child) => {
+        if (
+          child &&
+          child?.componentOptions &&
+          this.toPascal(child.componentOptions.tag || '') === name
+        ) {
+          list.push(child)
+        } else if (child?.children) {
+          this.getComponent(child.children, name, list)
+        }
+      })
+      return list
+    }
+  },
+  render(h) {
+    const mWidth = (this.maxWidth && `max-w-${this.maxWidth}`) || '',
+      headerStyle = `${mWidth} 
+        w-full flex items-center px-6`,
+      header = (
+        <header class={headerStyle}>
+          <div class="first flex items-center flex-1">{this.$slots.brand}</div>
+          <div class={this.linkSlotStyle}>{this.$slots.links}</div>
+          <div class="third flex flex-1 items-center space-x-4 justify-end">{this.$slots.cta}</div>
+          <div class="flex cursor-pointer lg:hidden space-x-2 pl-2" on-click={this.toggleModal}>
+            <z-icon icon="menu" size="medium"></z-icon>
+          </div>
+        </header>
+      ),
+      menuItems = this.$slots.links?.map((child) => {
+        const options = child.componentOptions
+        if (options && this.toPascal(options.tag || '') === 'ZMenu') {
+          if (options.propsData?.collapseOnMobile) {
+            const items = this.getComponent(options.children, 'ZMenuItem'),
+              // Checks if Menu Items are collapsible in Mobile, if true then render an accordion
+              // Else the Menu item remains the same
+              accordionItems = items.map((item) => {
+                return h(
+                  'div',
+                  {
+                    domProps: {
+                      key: item.key
+                    }
+                  },
+                  item?.componentOptions?.children
+                )
+              })
+            return h(ZAccordionItem, {
+              ...options.data,
+              props: {
+                title: 'Resources',
+                ...options.propsData
+              },
+              class: {
+                'px-4 py-2 border-b border-ink-200 lg:border-0': true
+              },
+              scopedSlots: {
+                default: () => accordionItems
+              }
+            })
+          } else {
+            // If the menu item is a List Item Component, it will be rendered as a separate component
+            // from the Menu Component
+            const listItems = this.getComponent(options.children, 'ZList')
+            return h('div', listItems)
+          }
+        }
+        return child
+      }),
+      mobileHeader = (
+        // Mobile Header Section
+        <div class={this.mobHeaderStyle}>
+          <div
+            class="flex cursor-pointer justify-end p-4 border-b border-ink-200"
+            on-click={this.toggleModal}
+          >
+            <z-icon icon="x" size="medium" color="vanilla-100"></z-icon>
+          </div>
+          {menuItems}
+          <div class="flex flex-col space-y-4 p-4">{this.$slots.cta}</div>
+        </div>
+      )
+    return (
+      // Entire Header Wrapper
+      <div class={this.headerWrapperStyle}>
+        {header}
+        {mobileHeader}
+      </div>
+    )
+  }
+}
+</script>

--- a/src/components/ZNavBar/index.ts
+++ b/src/components/ZNavBar/index.ts
@@ -1,0 +1,3 @@
+import ZNavBar from './ZNavBar.vue'
+
+export default ZNavBar

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,9 @@ import ZBadge from './components/ZBadge/index'
 import ZPagination from './components/ZPagination/index'
 import ZList from './components/ZList/index'
 import ZListItem from './components/ZListItem/index'
+import ZNavBar from './components/ZNavBar/index'
+import ZAccordion from './components/ZAccordion/index'
+import ZAccordionItem from './components/ZAccordionItem/index'
 
 // Marketing components
 import ZFooter from './components/marketing/ZFooter'
@@ -117,7 +120,10 @@ const components = [
   ZRelatedArticles,
   ZHero,
   ZListItem,
-  ZList
+  ZList,
+  ZNavBar,
+  ZAccordion,
+  ZAccordionItem
 ]
 
 const install = (Vue: any) => {
@@ -237,3 +243,6 @@ export { default as ZContentGuide } from './components/marketing/layouts/ZConten
 export { default as ZPageLabel } from './components/marketing/ZPageLabel/index'
 export { default as ZList } from './components/ZList/index'
 export { default as ZListItem } from './components/ZListItem/index'
+export { default as ZAccordion } from './components/ZAccordion/index'
+export { default as ZAccordionItem } from './components/ZAccordionItem/index'
+export { default as ZNavBar } from './components/ZNavBar/index'

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -543,7 +543,8 @@ module.exports = {
       10: 'repeat(10, minmax(0, 1fr))',
       11: 'repeat(11, minmax(0, 1fr))',
       12: 'repeat(12, minmax(0, 1fr))',
-      'repo-header': '1fr 1fr minmax(auto, 24rem)'
+      'repo-header': '1fr 1fr minmax(auto, 24rem)',
+      footer: 'repeat(5, 1fr) 2fr 1.5fr'
     },
     gridColumn: {
       auto: 'auto',
@@ -600,7 +601,8 @@ module.exports = {
       3: 'repeat(3, minmax(0, 1fr))',
       4: 'repeat(4, minmax(0, 1fr))',
       5: 'repeat(5, minmax(0, 1fr))',
-      6: 'repeat(6, minmax(0, 1fr))'
+      6: 'repeat(6, minmax(0, 1fr))',
+      footer: 'auto 15%'
     },
     gridRow: {
       auto: 'auto',
@@ -1116,8 +1118,8 @@ module.exports = {
     ],
     borderOpacity: ['responsive', 'hover', 'focus'],
     borderRadius: ['responsive'],
-    borderStyle: ['responsive', 'last'],
-    borderWidth: ['responsive', 'even', 'last'],
+    borderStyle: ['responsive', 'last', 'first'],
+    borderWidth: ['responsive', 'even', 'last', 'first'],
     boxShadow: ['responsive', 'hover', 'focus', 'group-hover', 'focus-within'],
     boxSizing: ['responsive'],
     container: ['responsive'],

--- a/tests/unit/ZAccordion.spec.ts
+++ b/tests/unit/ZAccordion.spec.ts
@@ -1,0 +1,70 @@
+import ZAccordion from '../../src/components/ZAccordion'
+import ZAccordionItem from '../../src/components/ZAccordionItem'
+import ZIcon from '../../src/components/ZIcon'
+
+import { mount } from '@vue/test-utils'
+
+const DefaultAccordion = {
+  template: `<z-accordion class="text-vanilla-100">
+          <z-accordion-item title="Consistency">
+            <div>Consistent with real life: in line with the process and logic of real life, and comply with languages and habits that the users are used to;</div>
+            <div>Consistent within interface: all elements should be consistent, such as: design style, icons and texts, position of elements, etc.</div>
+          </z-accordion-item>
+          <z-accordion-item title="Feedback">
+            <div>Consistent with real life: in line with the process and logic of real life, and comply with languages and habits that the users are used to;</div>
+            <div>Consistent within interface: all elements should be consistent, such as: design style, icons and texts, position of elements, etc.</div>
+          </z-accordion-item>
+          <z-accordion-item title="Efficiency">
+            <div>Consistent with real life: in line with the process and logic of real life, and comply with languages and habits that the users are used to;</div>
+            <div>Consistent within interface: all elements should be consistent, such as: design style, icons and texts, position of elements, etc.</div>
+          </z-accordion-item>
+        </z-accordion>`,
+  components: {
+    ZAccordion,
+    ZAccordionItem
+  }
+}
+
+const CustomizedAccordion = {
+  template: `<div class='padded-container flex items-center w-52'>
+        <z-accordion class="text-vanilla-100 w-full">
+          <z-accordion-item :is-open="openAccordion">
+            <template v-slot:title="{ open, toggleAccordion }">
+              <div class="flex items-center cursor-pointer w-full" @click="toggleAccordion()">
+                <span class="flex-1 font-medium text-slate">Resources</span>
+                <z-icon icon="chevron-right" 
+                    size="small" color="slate" 
+                    class="transform"
+                    :class="open ? 'animate-first-quarter-spin rotate-90' : 'animate-reverse-quarter-spin rotate-0'"></z-icon>
+              </div>
+            </template>
+            <div class="flex flex-col text-sm space-y-4 py-3">
+              <a v-for="link in links" :key="link" href="#" class="hover:text-juniper transition-all duration-75 ease-in-out">{{link}}</a>
+            </div>
+          </z-accordion-item>
+        </z-accordion>
+    </div>`,
+  data() {
+    return {
+      openAccordion: false,
+      links: ['Documentation', 'Discourse Form', 'Learning Center', 'Blog', 'Slack User Group']
+    }
+  },
+  components: {
+    ZAccordion,
+    ZAccordionItem,
+    ZIcon
+  }
+}
+
+describe('Accordions', () => {
+  it('renders a default accordion', () => {
+    let wrapper = mount(DefaultAccordion)
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('renders a customized accordion', () => {
+    let wrapper = mount(CustomizedAccordion)
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})

--- a/tests/unit/__snapshots__/ZAccordion.spec.ts.snap
+++ b/tests/unit/__snapshots__/ZAccordion.spec.ts.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Accordions renders a customized accordion 1`] = `
+<div class="padded-container flex items-center w-52">
+  <div class="text-vanilla-100 w-full">
+    <div class="z-accordion-item p-4">
+      <div class="flex items-center cursor-pointer w-full"><span class="flex-1 font-medium text-slate">Resources</span> <svg viewBox="0 0 24 24" fill="none" class="stroke-2 transform z-icon w-4 h-4 z-icon--chevron-right text-slate animate-reverse-quarter-spin rotate-0">
+          <polyline points="9 18 15 12 9 6"></polyline>
+        </svg></div>
+      <div class="overflow-scroll transition-max-height duration-300 ease-in-out text-sm leading-6 max-h-0">
+        <div class="flex flex-col text-sm space-y-4 py-3"><a href="#" class="hover:text-juniper transition-all duration-75 ease-in-out">Documentation</a><a href="#" class="hover:text-juniper transition-all duration-75 ease-in-out">Discourse Form</a><a href="#" class="hover:text-juniper transition-all duration-75 ease-in-out">Learning Center</a><a href="#" class="hover:text-juniper transition-all duration-75 ease-in-out">Blog</a><a href="#" class="hover:text-juniper transition-all duration-75 ease-in-out">Slack User Group</a></div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Accordions renders a default accordion 1`] = `
+<div class="text-vanilla-100">
+  <div class="z-accordion-item p-4">
+    <div class="flex items-center transition-all duration-700 ease-in-out group cursor-pointer"><span class="flex-1">Consistency</span> <svg viewBox="0 0 24 24" fill="none" class="stroke-2 transform z-icon w-4 h-4 sm:w-6 sm:h-6 z-icon--chevron-down text-slate group-hover:text-vanilla-100">
+        <polyline points="6 9 12 15 18 9"></polyline>
+      </svg></div>
+    <div class="overflow-scroll transition-max-height duration-300 ease-in-out text-sm leading-6 max-h-0">
+      <div>Consistent with real life: in line with the process and logic of real life, and comply with languages and habits that the users are used to;</div>
+      <div>Consistent within interface: all elements should be consistent, such as: design style, icons and texts, position of elements, etc.</div>
+    </div>
+  </div>
+  <div class="z-accordion-item p-4">
+    <div class="flex items-center transition-all duration-700 ease-in-out group cursor-pointer"><span class="flex-1">Feedback</span> <svg viewBox="0 0 24 24" fill="none" class="stroke-2 transform z-icon w-4 h-4 sm:w-6 sm:h-6 z-icon--chevron-down text-slate group-hover:text-vanilla-100">
+        <polyline points="6 9 12 15 18 9"></polyline>
+      </svg></div>
+    <div class="overflow-scroll transition-max-height duration-300 ease-in-out text-sm leading-6 max-h-0">
+      <div>Consistent with real life: in line with the process and logic of real life, and comply with languages and habits that the users are used to;</div>
+      <div>Consistent within interface: all elements should be consistent, such as: design style, icons and texts, position of elements, etc.</div>
+    </div>
+  </div>
+  <div class="z-accordion-item p-4">
+    <div class="flex items-center transition-all duration-700 ease-in-out group cursor-pointer"><span class="flex-1">Efficiency</span> <svg viewBox="0 0 24 24" fill="none" class="stroke-2 transform z-icon w-4 h-4 sm:w-6 sm:h-6 z-icon--chevron-down text-slate group-hover:text-vanilla-100">
+        <polyline points="6 9 12 15 18 9"></polyline>
+      </svg></div>
+    <div class="overflow-scroll transition-max-height duration-300 ease-in-out text-sm leading-6 max-h-0">
+      <div>Consistent with real life: in line with the process and logic of real life, and comply with languages and habits that the users are used to;</div>
+      <div>Consistent within interface: all elements should be consistent, such as: design style, icons and texts, position of elements, etc.</div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Signed-off-by: Ruphaa Ganesh <ruphaa@deepsource.io>

This PR includes the accordion component to the Zeal along with their respective stories and tests. This PR also contains the implementation stories for the Footer section as a part of Accordion Story

**Components Introduced**: ZAccordion and ZAccordionItem

### Properties

**title**:  Any text
**isOpen**: ```true``` and ```false```
**Data Exposed**: ```open``` and ```toggleAccordion```
**Slots Available**: ```title``` and ```default```

### Usage

**Basic Usage**

```vue
<z-accordion class="text-vanilla-100">
  <z-accordion-item title="Consistency">
    <div>Consistent with real life: in line with the process and logic of real life, and comply with languages and habits that the users are used to;</div>
  </z-accordion-item>
</z-accordion>
```

**Customized Usage**

```vue
<z-accordion class="text-vanilla-100">
  <z-accordion-item>
  <template v-slot:title="{ open, toggleAccordion }">
    <div class="flex items-center cursor-pointer w-full" @click="toggleAccordion()">
      <span class="flex-1 font-medium text-slate">Resources</span>
     </div>
  </template>
   <div>Consistent with real life: in line with the process and logic of real life, and comply with languages and habits that the users are used to;</div>
  </z-accordion-item>
</z-accordion>
```
**NavBar Usage**

```vue
<z-nav-bar class="text-vanilla-100">
    <template slot="brand">
        <img class="h-4 sm:h-5 lg:h-7 max-w-none" src="https://assets.deepsource.io/fc583c0/images/logo-wordmark-white.svg"/>
    </template>
    <template slot="links">
         <a class="flex px-4 py-2" href="https://deepsource.io/">Enterprise</a>
          <a class="flex px-4 py-2" href="https://deepsource.io/">Integrations</a>
    </template>
    <template slot="cta">
        <z-button color="link" type="link">Log in</z-button>
        <z-button color="primary"  spacing="px-4 lg:px-6">Sign up</z-button>
    </template>
</z-nav-bar>
```

### Preview

![image](https://user-images.githubusercontent.com/73866406/107602020-57ba2d00-6c4e-11eb-8de4-b4632873b651.png)

![image](https://user-images.githubusercontent.com/73866406/107602031-5db00e00-6c4e-11eb-9c24-d8f2ece1104f.png)

### Marketing Site Footer Section

** Desktop View**

![image](https://user-images.githubusercontent.com/73866406/107780181-5bdc6c80-6d6c-11eb-98b1-be9affca9aed.png)

** Mobile View**

![image](https://user-images.githubusercontent.com/73866406/107780459-b4ac0500-6d6c-11eb-815e-f2a97897e12d.png)

### Marketing Site NavBar Section

https://www.loom.com/share/0cd7cef385f54f3a889b4aed63eeff1d

### TODO

- [x] VQA (In Progress)
- [x] Define a property to detect the screen size in the accordion story for the footer
- [x] Ask Ayushi how should the Ipad/tablet view look
- [x] VQA for Footer
- [ ] VQA for NavBar
- [x] Introduce NavBar Component to Zeal
- [ ] Delete the other Nav files once the review is done