### PR TITLE
Mar 915 style fixes in navbar

### DIFF
--- a/src/components/ZNavBar/ZNavBar.stories.ts
+++ b/src/components/ZNavBar/ZNavBar.stories.ts
@@ -87,8 +87,8 @@ export const Horizontal = () => ({
                         <a class="flex px-4 py-2 hover:bg-ink-300 border-b border-ink-200 lg:border-0" href="https://deepsource.io/pricing">Pricing</a>
                     </template>
                     <template slot="cta">
-                        <z-button color="link" type="link" class="text-xs sm:text-sm lg:text-base">Log in</z-button>
-                        <z-button color="primary" size="none" spacing="px-4 lg:px-6" class="text-xxs sm:text-xs lg:text-sm h-6 sm:h-8">Sign up</z-button>
+                        <z-button color="link" type="link" class="text-sm sm:text-sm lg:text-base whitespace-nowrap">Log in</z-button>
+                        <z-button color="primary" size="none" spacing="px-4 lg:px-6" class="text-sm lg:text-md h-6 sm:h-8 whitespace-nowrap">Sign up</z-button>
                     </template>
                 </z-nav-bar>
     <div class="prose prose-sm sm:prose sm:max-w-none mx-auto px-10 py-36">

--- a/src/components/ZNavBar/ZNavBar.vue
+++ b/src/components/ZNavBar/ZNavBar.vue
@@ -51,7 +51,7 @@ export default {
     },
     mobHeaderStyle() {
       return `${this.isOpen ? 'right-0' : '-right-full'} 
-              overflow-y-scroll lg:-right-full w-full h-screen absolute flex flex-col space-y-2 transition-all duration-700 ease-in-out top-0 bg-ink-300 flex flex-col`
+              overflow-y-scroll lg:-right-full w-full h-screen absolute flex flex-col space-y-2 transition-all duration-300 ease-in-out top-0 bg-ink-300 flex flex-col`
     },
     linkSlotStyle() {
       return `${this.hideOnScroll} 
@@ -91,7 +91,7 @@ export default {
         <header class={headerStyle}>
           <div class="first flex items-center flex-1">{this.$slots.brand}</div>
           <div class={this.linkSlotStyle}>{this.$slots.links}</div>
-          <div class="third flex flex-1 items-center space-x-4 justify-end">{this.$slots.cta}</div>
+          <div class="third flex flex-1 items-center space-x-3 justify-end">{this.$slots.cta}</div>
           <div class="flex cursor-pointer lg:hidden space-x-2 pl-2" on-click={this.toggleModal}>
             <z-icon icon="menu" size="medium"></z-icon>
           </div>


### PR DESCRIPTION
Changes:

* Stopped button text wrapping when viewport gets extremely small by adding `whitespace-nowrap` to button text classes
* Adjusted spacing between the CTA slot items to be more in line with spacing of elements around it
* Adjusted text base size and responsive sizes to not be too small at extremely small viewports, i.e text doesn't get smaller than `sm` anymore