### PR TITLE
fix: don't set type attr for links

### DIFF
--- a/src/components/ZButton/ZButton.vue
+++ b/src/components/ZButton/ZButton.vue
@@ -17,7 +17,7 @@
       `${stylesBasedOnColor}`,
       icon && iconStyle
     ]"
-    :type="type"
+    :type="isLink ? null : type"
   >
     <z-icon v-if="icon" :icon="icon" :color="iconColor" :size="iconSize"></z-icon>
     <slot v-else>Click</slot>


### PR DESCRIPTION
Setting `type` attribute for `a` tag breaks in Safari. Originally the `type` attribute for links is a hint for the MIME type of the referenced resource [[ref](https://www.w3.org/TR/html52/textlevel-semantics.html#the-a-element)], however safari infers this differently for some reason.

This PR fixes this behaviour