### PR TITLE
fix tests for ZAnimatedInteger

### DIFF
--- a/tests/unit/ZAnimatedInteger.spec.ts
+++ b/tests/unit/ZAnimatedInteger.spec.ts
@@ -30,11 +30,11 @@ const randomValues = Array.from({ length: 5 }, () => {
 })
 
 describe('Animation', () => {
-  test.each(randomValues)('updates to correct value', async val => {
+  test.each(randomValues)('updates to correct value', async (val) => {
     const wrapper = mount(AnimateInteger)
 
     wrapper.vm.updateValue(val)
-    await new Promise(resolve =>
+    await new Promise((resolve) =>
       setTimeout(() => {
         expect(wrapper.find('#finalValue').text()).toBe(`${val}`)
         resolve(val)


### PR DESCRIPTION
The test for Animated Integer are a bit flaky, dealing with adhoc promises for simulating timeouts. Extended the `setTimeout` duration here