### PR TITLE
New keys for spock bot

### DIFF
--- a/.github/workflows/publish-zeal-pkg.yml
+++ b/.github/workflows/publish-zeal-pkg.yml
@@ -21,8 +21,8 @@ jobs:
         id: import_gpg_sign_commits
         uses: crazy-max/ghaction-import-gpg@v3
         with:
-          gpg-private-key: ${{ secrets.SPOCK_GPG_KEY }}
-          passphrase: ${{ secrets.SPOCK_GPG_KEY_PASSPHRASE }}
+          gpg-private-key: ${{ secrets.SPOCK1966_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.SPOCK1966_GPG_KEY_PASSPHRASE }}
           git-user-signingkey: true
           git-commit-gpgsign: true
 
@@ -30,8 +30,8 @@ jobs:
         env:
           auth_token: ${{ secrets.SPOCK_PAT }}
         run: |
-          git config --global user.email "bot@deepsource.io"
-          git config --global user.name "deepsourcebot"
+          git config --global user.email "spock1966@deepsource.io"
+          git config --global user.name "spock1966"
           npm version patch
           git push
 


### PR DESCRIPTION
Added new GPG keys so that Spock bot signs the commit instead of Deepsource Bot