### PR TITLE
chore: build before publish

### DIFF
--- a/.github/workflows/publish-zeal-pkg.yml
+++ b/.github/workflows/publish-zeal-pkg.yml
@@ -40,10 +40,8 @@ jobs:
       - name: Install Yarn
         run: yarn
 
-      - name: Test And Build Library Icons
-        id: build
-        run: |
-          yarn test:unit && yarn build-lib-icons
+      - name: Test
+        run: yarn test:unit
 
   publish-zeal-package:
     runs-on: ubuntu-latest
@@ -59,6 +57,9 @@ jobs:
 
       - name: Temp disable "private"
         run: sed '/private/ s/true/false/' -i package.json
+        
+      - name: Build Library Icons
+        run: yarn build-lib-icons
         
       - name: Publish Zeal Package
         uses: actions/setup-node@v2


### PR DESCRIPTION
The `dist` folder generated after build is not committed to the repo. This behaviour is intentional.

In the second stage of the workflow, the code is fetched from origin directly and published as is without the `dist` folder. This PR fixes it.