### PR TITLE
fix: backdrop filter fix for chart tooltip

### DIFF
--- a/src/assets/css/chart.css
+++ b/src/assets/css/chart.css
@@ -17,7 +17,19 @@
 }
 
 .z-chart-wrapper .graph-svg-tip {
-  @apply border border-ink-100 bg-ink-300 bg-opacity-25 backdrop-blur !important;
+  @apply border border-ink-100 bg-ink-300 backdrop-blur !important;
+}
+
+@supports (backdrop-filter: blur(1px)) {
+  .z-chart-wrapper .graph-svg-tip {
+    @apply bg-opacity-25 !important;
+  }
+}
+
+@supports not (backdrop-filter: blur(1px)) {
+  .z-chart-wrapper .graph-svg-tip {
+    @apply bg-opacity-90 !important;
+  }
 }
 
 .z-chart-wrapper .graph-svg-tip .svg-pointer {


### PR DESCRIPTION
### Before Fix

<img width="1185" alt="Screenshot 2021-04-28 at 19 35 38" src="https://user-images.githubusercontent.com/77610151/116417490-ef481880-a858-11eb-8abc-59c62d3f3982.png">


### After Fix

![image](https://user-images.githubusercontent.com/77610151/116417478-eb1bfb00-a858-11eb-8e48-e6d18f0c0184.png)
