### PR TITLE
[PLT-1538] refactor zmenu width options

### DIFF
--- a/src/components/ZMenu/ZMenu.vue
+++ b/src/components/ZMenu/ZMenu.vue
@@ -40,28 +40,28 @@ export default Vue.extend({
     direction: {
       type: String,
       default: 'right',
-      validator: function(value: string): boolean {
+      validator: function (value: string): boolean {
         return ['left', 'right'].includes(value)
       }
     },
     placement: {
       type: String,
       default: 'bottom',
-      validator: function(value: string): boolean {
+      validator: function (value: string): boolean {
         return ['top', 'bottom'].includes(value)
       }
     },
     size: {
       type: String,
       default: 'base',
-      validator: function(value: string): boolean {
+      validator: function (value: string): boolean {
         return ['small', 'base', 'large'].includes(value)
       }
     },
     width: {
       type: String,
       default: 'base',
-      validator: function(value: string): boolean {
+      validator: function (value: string): boolean {
         return ['x-small', 'small', 'base', 'large', 'x-large'].includes(value)
       }
     },


### PR DESCRIPTION
This PR refactors the `ZMenu` width options to include the following values

`x-small`, `small`, `base`, `large`, `x-large`


![image](https://user-images.githubusercontent.com/77610151/117415911-79b60980-af36-11eb-8a75-6650b99128ee.png)
