### PR TITLE
Add active scope to tab item default slot

### DIFF
--- a/src/components/ZTabs/ZTabItem/ZTabItem.vue
+++ b/src/components/ZTabs/ZTabItem/ZTabItem.vue
@@ -6,7 +6,7 @@
     :isActive="isActive"
     :disabled="disabled"
   >
-    <slot></slot>
+    <slot :active="active"></slot>
   </z-tab>
 </template>
 


### PR DESCRIPTION
Added the `active` state scope to the default slot for ZTabItem