### PR TITLE
allow custom secondary action label

### DIFF
--- a/src/components/ZConfirm/ZConfirm.vue
+++ b/src/components/ZConfirm/ZConfirm.vue
@@ -10,9 +10,9 @@
         </slot>
         <slot name="footer">
           <div class="mt-6 space-x-4 text-right text-vanilla-100 flex items-center justify-end">
-            <z-button buttonType="ghost" class="text-vanilla-100" size="small" @click="close"
-              >Cancel</z-button
-            >
+            <z-button buttonType="ghost" class="text-vanilla-100" size="small" @click="close">{{
+              secondaryActionLabel
+            }}</z-button>
             <z-button
               :icon="primaryActionIcon"
               class="modal-primary-action"
@@ -47,6 +47,10 @@ export default Vue.extend({
     primaryActionLabel: {
       type: String,
       default: 'Confirm'
+    },
+    secondaryActionLabel: {
+      type: String,
+      default: 'Cancel'
     },
     primaryActionIcon: {
       type: String,


### PR DESCRIPTION
The secondary action label "Cancel" looks confusing, this PR adds an option to allow changing that

<img width="513" alt="Screenshot 2021-06-03 at 22 02 18" src="https://user-images.githubusercontent.com/77610151/120679943-5f306b00-c4b7-11eb-869a-4bea2bd02304.png">
