### PR TITLE
[PLT-2334 ]refactor: use Array.prototype.includes() to check for existence

### DIFF
--- a/src/components/ZBadge/ZBadge.vue
+++ b/src/components/ZBadge/ZBadge.vue
@@ -38,14 +38,14 @@ export default Vue.extend({
       type: String,
       default: 'sm',
       validator(val) {
-        return ['sm', 'md', 'lg'].indexOf(val) > -1
+        return ['sm', 'md', 'lg'].includes(val)
       }
     },
     type: {
       type: String,
       default: 'default',
       validator(val) {
-        return ['default', 'success', 'warning', 'info', 'danger'].indexOf(val) > -1
+        return ['default', 'success', 'warning', 'info', 'danger'].includes(val)
       }
     },
     position: {


### PR DESCRIPTION
This PR aims at replacing instances of `Array.prototype.indexOf()` with `Array.prototype.includes()` to check for existence to be consistent with rest of the codebase.