### PR TITLE
Fix memory leak in ZTestimonials

### DIFF
--- a/src/components/marketing/sections/ZTestimonials/ZTestimonials.vue
+++ b/src/components/marketing/sections/ZTestimonials/ZTestimonials.vue
@@ -115,6 +115,9 @@ export default Vue.extend({
   mounted() {
     this.setTestimonialInterval()
   },
+  beforeDestroy() {
+    clearInterval(this.interval)
+  },
   methods: {
     setTestimonialInterval() {
       this.interval = setInterval(() => {


### PR DESCRIPTION
ZTestimonials calls `setInterval()` in the `mounted` hook to begin auto-cycling between items. This wasn't terminated anywhere resulting in a memory leak when navigating away from the page on which this component exists:
![Screenshot 2021-08-18 at 9 38 45 PM](https://user-images.githubusercontent.com/80349145/129936489-5ae2d8ea-4d42-49bc-ad32-bf5368bae31e.png)

Added a call to `clearInterval()` in the component's `beforeDestroy` hook
