### PR TITLE
[PLT-2472] chore: prevent publishing with changes to lock file

### DIFF
--- a/.github/workflows/publish-zeal-pkg.yml
+++ b/.github/workflows/publish-zeal-pkg.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths-ignore:
       - 'package.json'
+      - 'yarn.lock'
 
 jobs:
   bump-package-version:


### PR DESCRIPTION
This PR aims at updating the `publish-zeal-pkg` workflow config.