### PR TITLE
Fix footer width class

### DIFF
--- a/src/components/marketing/ZFooter/ZFooter.vue
+++ b/src/components/marketing/ZFooter/ZFooter.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- prettier-ignore -->
   <footer
-    class="w-full-screen flex flex-col justify-between bg-transparent text-vanilla-100 border-t border-ink-200 min-h-102 pb-10 pt-20"
+    class="w-full flex flex-col justify-between bg-transparent text-vanilla-100 border-t border-ink-200 min-h-102 pb-10 pt-20"
   >
     <div class="md:flex items-start w-screen lg:mx-auto" :class="[`${CONTAINERS[container].classes}`]">
       <!-- Brand -->


### PR DESCRIPTION
found on the [whitepaper page](https://deepsource.io/resources/whitepapers/state-of-go/):

![image](https://user-images.githubusercontent.com/86737547/130946914-56889848-79d0-4594-8850-69155b4af1d2.png)

There's horizontal scroll (1080p screen, chrome). This class change seems to fix that.

There might be unintended side effects from this PR, which I'm not sure of.