### PR TITLE
Feat: Add before element to headings to fix scroll behavior

### DIFF
--- a/src/helpers/tailwind/nuxt-styles.js
+++ b/src/helpers/tailwind/nuxt-styles.js
@@ -7,7 +7,7 @@ const contentStyles = function (theme) {
       color: theme('colors.slate'),
       position: 'absolute'
     },
-    'h2::before, h3::before, h4::before, h5::before' : {
+    'h2::before, h3::before, h4::before, h5::before': {
       content: '" "',
       display: 'block',
       marginTop: '-5rem',


### PR DESCRIPTION
Added a `::before` element to headings `h2` `h3` `h4` `h5` with fixed height and negative vertical margin of 5 rem. This fixes headings being hidden behind the navbar when scrolled to via a url fragment. 