### PR TITLE
fix: add edge case of visible pages being >= total pages to z-pagination

### DIFF
--- a/src/components/ZPagination/ZPagination.vue
+++ b/src/components/ZPagination/ZPagination.vue
@@ -114,6 +114,7 @@ export default Vue.extend({
     pageCount(): number {
       // if ends are visible, remove two counts from total visible to offset end indicators
       // otherwise totalvisible minus on to offset for active index
+      if (this.totalVisible >= this.totalPages) return this.totalVisible
       return this.showEnds ? this.totalVisible - 2 : this.totalVisible - 1
     },
     showFirst(): boolean {


### PR DESCRIPTION
When visible pages were equal >= total pages, ellipses were still being shown.

Before:
![image](https://user-images.githubusercontent.com/90057287/134361890-9713757a-4721-432a-906a-e05ddff4a045.png)

After:
![image](https://user-images.githubusercontent.com/90057287/134362001-96e42a7e-6958-443d-8e46-450fe6bef00b.png)
