### PR TITLE
fix: navbar padding on md breakpoint and higher

### DIFF
--- a/src/components/ZNavBar/ZNavBar.vue
+++ b/src/components/ZNavBar/ZNavBar.vue
@@ -78,7 +78,7 @@ export default {
   render(h) {
     const mWidth = (this.maxWidth && `max-w-${this.maxWidth}`) || '',
       headerStyle = `${mWidth}
-        w-full flex items-center px-6 md:px-0 space-x-3`,
+        w-full flex items-center px-6 space-x-3`,
       header = (
         <nav class={headerStyle}>
           <div class="first flex items-center flex-1">{this.$slots.brand}</div>


### PR DESCRIPTION
This PR reverses a [change in a previous commit](https://github.com/deepsourcelabs/zeal/commit/3801753a742fade529e8b7cee83fb29de5d5008a) that incorrectly removed all horizontal padding at the `md` breakpoint and higher, resulting in navbar elements to be flush on the boundaries of the viewport:

![Screenshot 2021-12-14 at 2 39 45 PM](https://user-images.githubusercontent.com/80349145/145968015-fbd261ce-52af-40e9-8dc6-6ec0ef19a48b.png)
