### PR TITLE
fix: prevent double click event emit in z-menu-item

### DIFF
--- a/src/components/ZMenu/ZMenuItem/ZMenuItem.vue
+++ b/src/components/ZMenu/ZMenuItem/ZMenuItem.vue
@@ -47,9 +47,7 @@ export default Vue.extend({
     }
   },
   methods: {
-    itemClicked(event: Event): void {
-      this.$emit('click', event)
-
+    itemClicked(): void {
       if (this.closeOnClick) {
         const parent = this.$parent as ZMenuParentT
         parent.close()


### PR DESCRIPTION
The click event would be triggered on the v-on="$listeners as well as the click emitted in the function. So any events would be triggered twice. This PR fixes this. It's not a breaking change