### PR TITLE
fix: make z-scrollspy conditional styles purgeable

### DIFF
--- a/src/components/marketing/ZScrollSpy/ZScrollSpy.vue
+++ b/src/components/marketing/ZScrollSpy/ZScrollSpy.vue
@@ -4,10 +4,7 @@
       v-for="heading in headingsMap"
       :key="heading.id"
       class="leading-4 pointer-events-none group-hover:pointer-events-auto"
-      :class="[
-        `${HEADINGS[heading.tagName].indentClass}`,
-        `${HEADINGS[heading.tagName].extras}`
-      ]"
+      :class="[`${HEADINGS[heading.tagName].indentClass}`, `${HEADINGS[heading.tagName].extras}`]"
     >
       <div
         class="absolute left-0 -mt-2 group-hover:w-0 group-hover:opacity-0 transition-all ease-bounce"


### PR DESCRIPTION
* Removed the `align` prop and related logic, as the ScrollSpy will always be used on the left
* Refactored the conditional styles for ScrollSpy items to contain the entire class string rather than composing them with template literals, which was resulting in certain styles being purged and thus incorrect positioning for items in the ScrollSpy. 