### PR TITLE
fix: color of `a code` in prose blocks

### DIFF
--- a/src/helpers/tailwind/typography.js
+++ b/src/helpers/tailwind/typography.js
@@ -1,4 +1,4 @@
-const BEFORE_LIST_ITEM = function(theme, muted = false) {
+const BEFORE_LIST_ITEM = function (theme, muted = false) {
   return {
     content: '"—"',
     marginRight: theme('spacing.2'),
@@ -11,7 +11,7 @@ const BEFORE_LIST_ITEM = function(theme, muted = false) {
   }
 }
 
-const DEFAULT = function(theme) {
+const DEFAULT = function (theme) {
   return {
     color: theme('colors.vanilla.100'),
     '[class~="lead"]': {
@@ -145,7 +145,7 @@ const DEFAULT = function(theme) {
   }
 }
 
-const SMALL_SCREEN_CSS = function(theme) {
+const SMALL_SCREEN_CSS = function (theme) {
   return {
     'ul > li::before': {
       ...BEFORE_LIST_ITEM(theme)
@@ -159,7 +159,7 @@ const SMALL_SCREEN_CSS = function(theme) {
   }
 }
 
-const LARGE_SCREEN_CSS = function(theme) {
+const LARGE_SCREEN_CSS = function (theme) {
   return {
     'ul > li::before': {
       ...BEFORE_LIST_ITEM(theme)
@@ -170,7 +170,7 @@ const LARGE_SCREEN_CSS = function(theme) {
   }
 }
 
-const MUTED = function(theme) {
+const MUTED = function (theme) {
   return {
     'ul > li::before': {
       ...BEFORE_LIST_ITEM(theme, true)
@@ -183,7 +183,7 @@ const MUTED = function(theme) {
   }
 }
 
-const RTE = function(theme) {
+const RTE = function (theme) {
   return {
     p: {
       fontSize: theme('fontSize.sm'),


### PR DESCRIPTION
## Changes

- Fix the color of `a code` in prose blocks.

Fixes PLT-4114.

## Preview

![image](https://user-images.githubusercontent.com/87606277/160833258-7c8e81d1-a637-4d08-bba7-eb3b941f958f.png)
