### PR TITLE
fix: incorrect variable name in ZConfirm template

### DIFF
--- a/src/components/ZConfirm/ZConfirm.vue
+++ b/src/components/ZConfirm/ZConfirm.vue
@@ -11,7 +11,7 @@
         <slot name="footer" :close="close">
           <div class="mt-6 space-x-4 text-right text-vanilla-100 flex items-center justify-end">
             <z-button
-              v-if="showSecondaryButton"
+              v-if="showSecondaryAction"
               buttonType="ghost"
               class="text-vanilla-100"
               size="small"


### PR DESCRIPTION
### Changes in this PR
Replaced the incorrectly named `showSecondaryButton` variable with `showSecondaryAction` in ZConfirm

### Screenshots
Before:
![Screenshot 2022-05-02 at 11 55 49 AM](https://user-images.githubusercontent.com/80349145/166193229-b2b802c3-40f2-43fb-9ec4-20fa1bc77ea1.png)

After:
![Screenshot 2022-05-02 at 11 55 56 AM](https://user-images.githubusercontent.com/80349145/166193232-dc2850a6-21d1-4576-a785-3833383347ce.png)


