### PR TITLE
feat: add transparent prop to ZDialogGeneric

### DIFF
--- a/src/components/ZDialogGeneric/ZDialogGeneric.vue
+++ b/src/components/ZDialogGeneric/ZDialogGeneric.vue
@@ -9,7 +9,7 @@
       <div
         v-if="showInternal"
         class="mx-auto sm:mb-12 rounded-t-lg sm:rounded-md bg-ink-300 transform-gpu w-full sm:w-auto"
-        :class="[transparent ? 'bg-opacity-0': 'shadow-md']"
+        :class="[transparent ? 'bg-opacity-0' : 'shadow-md']"
       >
         <slot :showInternal="showInternal" :close="close"></slot>
       </div>


### PR DESCRIPTION
### Changes in this PR

Added a `transparent: Boolean` prop to `ZDialogGeneric` to allow rendering the dialog without a background color or shadow, for cases when a different bg color or shadow is needed within the slot.