### PR TITLE
feat(ZTimelineItem): add the ability to specify a custom border width

### DIFF
--- a/src/components/ZTimeline/ZTimeline.stories.ts
+++ b/src/components/ZTimeline/ZTimeline.stories.ts
@@ -62,3 +62,43 @@ export const TimelineWithCustomIcon = () => ({
     </z-timeline>
     </div>`
 })
+
+export const TimelineWithCustomBorderWidth = () => ({
+  components: { ZTimeline, ZTimelineItem, ZAvatar },
+  template: `<div class='padded-container'>
+    <z-timeline>
+      <z-timeline-item content="Carter Workman" timestamp="Friday, 4:24PM" border-width-class="" class="h-32">
+        <template slot="icon">
+        <z-avatar
+          image="https://randomuser.me/api/portraits/women/24.jpg"
+          user-name="Akshay Paliwal"
+          size="sm"
+        ></z-avatar></template>
+      </z-timeline-item>
+      <z-timeline-item content="Carter Workman" timestamp="Friday, 4:24PM" border-width-class="" class="h-32">
+        <template slot="icon">
+        <z-avatar
+          image="https://randomuser.me/api/portraits/women/24.jpg"
+          user-name="Akshay Paliwal"
+          size="sm"
+        ></z-avatar></template>
+      </z-timeline-item>
+      <z-timeline-item content="Carter Workman" timestamp="Friday, 4:24PM" border-width-class="" class="h-32">
+        <template slot="icon">
+        <z-avatar
+          image="https://randomuser.me/api/portraits/women/24.jpg"
+          user-name="Akshay Paliwal"
+          size="sm"
+        ></z-avatar></template>
+      </z-timeline-item>
+      <z-timeline-item content="Carter Workman" timestamp="Friday, 4:24PM" border-width-class="" class="h-32">
+        <template slot="icon">
+        <z-avatar
+          image="https://randomuser.me/api/portraits/women/24.jpg"
+          user-name="Akshay Paliwal"
+          size="sm"
+        ></z-avatar></template>
+      </z-timeline-item>
+    </z-timeline>
+    </div>`
+})

--- a/src/components/ZTimeline/ZTimelineItem/ZTimelineItem.vue
+++ b/src/components/ZTimeline/ZTimelineItem/ZTimelineItem.vue
@@ -1,17 +1,20 @@
 <template>
-  <div class="timeline__item flex relative gap-x-2">
-    <div class="flex flex-col justify-center items-center gap-y-2">
-      <div class="w-6 h-6 flex justify-center items-center">
+  <div class="relative flex timeline__item gap-x-2">
+    <div class="flex flex-col items-center justify-center gap-y-2">
+      <div class="flex items-center justify-center w-6 h-6">
         <slot name="icon">
-          <span class="inline-block h-full w-full rounded-full bg-juniper"></span>
+          <span class="inline-block w-full h-full rounded-full bg-juniper"></span>
         </slot>
       </div>
       <span
-        class="h-full border-l border-2 rounded-sm left-4"
-        :class="{
-          'border-transparent': index === lastIndex,
-          'border-ink-100': index !== lastIndex
-        }"
+        class="h-full border-l rounded-sm left-4"
+        :class="[
+          {
+            'border-transparent': index === lastIndex,
+            'border-ink-100': index !== lastIndex
+          },
+          borderWidthClass
+        ]"
       ></span>
     </div>
     <slot>
@@ -34,6 +37,10 @@ export default {
     timestamp: {
       type: String,
       default: ''
+    },
+    borderWidthClass: {
+      type: String,
+      default: 'border-2'
     }
   },
   data() {

--- a/tests/unit/ZTimeline.spec.ts
+++ b/tests/unit/ZTimeline.spec.ts
@@ -41,6 +41,32 @@ const TimelineWithCustomIcon = {
   }
 }
 
+const TimelineWithCustomBorderWidth = {
+  template: `<z-timeline>
+      <z-timeline-item content="Carter Workman" timestamp="Friday, 4:24PM" border-width-class="" class="h-32">
+        <template slot="icon">
+        <z-avatar
+          image="https://randomuser.me/api/portraits/women/24.jpg"
+          user-name="Akshay Paliwal"
+          size="sm"
+        /></template>
+      </z-timeline-item>
+      <z-timeline-item content="Carter Workman" timestamp="Friday, 4:24PM" border-width-class="" class="h-32">
+        <template slot="icon">
+        <z-avatar
+          image="https://randomuser.me/api/portraits/women/24.jpg"
+          user-name="Akshay Paliwal"
+          size="sm"
+        /></template>
+      </z-timeline-item>
+      </z-timeline>`,
+  components: {
+    ZTimeline,
+    ZTimelineItem,
+    ZAvatar
+  }
+}
+
 describe('ZTimeline', () => {
   it('renders a default timeline component', () => {
     let wrapper = mount(BasicTimeline)
@@ -48,6 +74,10 @@ describe('ZTimeline', () => {
   })
   it('renders a timeline component with custom icon', () => {
     let wrapper = mount(TimelineWithCustomIcon)
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+  it('renders a timeline component with custom border width', () => {
+    let wrapper = mount(TimelineWithCustomBorderWidth)
     expect(wrapper.html()).toMatchSnapshot()
   })
 })

--- a/tests/unit/__snapshots__/ZTimeline.spec.ts.snap
+++ b/tests/unit/__snapshots__/ZTimeline.spec.ts.snap
@@ -2,18 +2,45 @@
 
 exports[`ZTimeline renders a default timeline component 1`] = `
 <div class="timeline flex flex-col gap-y-2">
-  <div class="timeline__item flex relative gap-x-2 h-32">
-    <div class="flex flex-col justify-center items-center gap-y-2">
-      <div class="w-6 h-6 flex justify-center items-center"><span class="inline-block h-full w-full rounded-full bg-juniper"></span></div> <span class="h-full border-l border-2 rounded-sm left-4 border-ink-100"></span>
+  <div class="relative flex timeline__item gap-x-2 h-32">
+    <div class="flex flex-col items-center justify-center gap-y-2">
+      <div class="flex items-center justify-center w-6 h-6"><span class="inline-block w-full h-full rounded-full bg-juniper"></span></div> <span class="h-full border-l rounded-sm left-4 border-ink-100 border-2"></span>
     </div>
     <div class="flex flex-col space-y-2 text-xs">
       <div class="text-vanilla-100">Carter Workman</div>
       <div class="text-vanilla-400">Friday, 4:24PM</div>
     </div>
   </div>
-  <div class="timeline__item flex relative gap-x-2 h-32">
-    <div class="flex flex-col justify-center items-center gap-y-2">
-      <div class="w-6 h-6 flex justify-center items-center"><span class="inline-block h-full w-full rounded-full bg-juniper"></span></div> <span class="h-full border-l border-2 rounded-sm left-4 border-ink-100"></span>
+  <div class="relative flex timeline__item gap-x-2 h-32">
+    <div class="flex flex-col items-center justify-center gap-y-2">
+      <div class="flex items-center justify-center w-6 h-6"><span class="inline-block w-full h-full rounded-full bg-juniper"></span></div> <span class="h-full border-l rounded-sm left-4 border-ink-100 border-2"></span>
+    </div>
+    <div class="flex flex-col space-y-2 text-xs">
+      <div class="text-vanilla-100">Carter Workman</div>
+      <div class="text-vanilla-400">Friday, 4:24PM</div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ZTimeline renders a timeline component with custom border width 1`] = `
+<div class="timeline flex flex-col gap-y-2">
+  <div class="relative flex timeline__item gap-x-2 h-32">
+    <div class="flex flex-col items-center justify-center gap-y-2">
+      <div class="flex items-center justify-center w-6 h-6"><a class="inline-block rounded-full bg-ink-300 p-0.5"><img src="https://randomuser.me/api/portraits/women/24.jpg" alt="Akshay Paliwal" class="rounded-full leading-none h-6 w-6 text-xs">
+          <!---->
+        </a></div> <span class="h-full border-l rounded-sm left-4 border-ink-100"></span>
+    </div>
+    <div class="flex flex-col space-y-2 text-xs">
+      <div class="text-vanilla-100">Carter Workman</div>
+      <div class="text-vanilla-400">Friday, 4:24PM</div>
+    </div>
+  </div>
+  <div class="relative flex timeline__item gap-x-2 h-32">
+    <div class="flex flex-col items-center justify-center gap-y-2">
+      <div class="flex items-center justify-center w-6 h-6"><a class="inline-block rounded-full bg-ink-300 p-0.5"><img src="https://randomuser.me/api/portraits/women/24.jpg" alt="Akshay Paliwal" class="rounded-full leading-none h-6 w-6 text-xs">
+          <!---->
+        </a></div> <span class="h-full border-l rounded-sm left-4 border-ink-100"></span>
     </div>
     <div class="flex flex-col space-y-2 text-xs">
       <div class="text-vanilla-100">Carter Workman</div>
@@ -25,22 +52,22 @@ exports[`ZTimeline renders a default timeline component 1`] = `
 
 exports[`ZTimeline renders a timeline component with custom icon 1`] = `
 <div class="timeline flex flex-col gap-y-2">
-  <div class="timeline__item flex relative gap-x-2 h-32">
-    <div class="flex flex-col justify-center items-center gap-y-2">
-      <div class="w-6 h-6 flex justify-center items-center"><a class="inline-block rounded-full bg-ink-300 p-0.5"><img src="https://randomuser.me/api/portraits/women/24.jpg" alt="Akshay Paliwal" class="rounded-full leading-none h-6 w-6 text-xs">
+  <div class="relative flex timeline__item gap-x-2 h-32">
+    <div class="flex flex-col items-center justify-center gap-y-2">
+      <div class="flex items-center justify-center w-6 h-6"><a class="inline-block rounded-full bg-ink-300 p-0.5"><img src="https://randomuser.me/api/portraits/women/24.jpg" alt="Akshay Paliwal" class="rounded-full leading-none h-6 w-6 text-xs">
           <!---->
-        </a></div> <span class="h-full border-l border-2 rounded-sm left-4 border-ink-100"></span>
+        </a></div> <span class="h-full border-l rounded-sm left-4 border-ink-100 border-2"></span>
     </div>
     <div class="flex flex-col space-y-2 text-xs">
       <div class="text-vanilla-100">Carter Workman</div>
       <div class="text-vanilla-400">Friday, 4:24PM</div>
     </div>
   </div>
-  <div class="timeline__item flex relative gap-x-2 h-32">
-    <div class="flex flex-col justify-center items-center gap-y-2">
-      <div class="w-6 h-6 flex justify-center items-center"><a class="inline-block rounded-full bg-ink-300 p-0.5"><img src="https://randomuser.me/api/portraits/women/24.jpg" alt="Akshay Paliwal" class="rounded-full leading-none h-6 w-6 text-xs">
+  <div class="relative flex timeline__item gap-x-2 h-32">
+    <div class="flex flex-col items-center justify-center gap-y-2">
+      <div class="flex items-center justify-center w-6 h-6"><a class="inline-block rounded-full bg-ink-300 p-0.5"><img src="https://randomuser.me/api/portraits/women/24.jpg" alt="Akshay Paliwal" class="rounded-full leading-none h-6 w-6 text-xs">
           <!---->
-        </a></div> <span class="h-full border-l border-2 rounded-sm left-4 border-ink-100"></span>
+        </a></div> <span class="h-full border-l rounded-sm left-4 border-ink-100 border-2"></span>
     </div>
     <div class="flex flex-col space-y-2 text-xs">
       <div class="text-vanilla-100">Carter Workman</div>


### PR DESCRIPTION
Add `borderWidthClass` prop that defaults to `border-2`.

Context: https://github.com/deepsourcelabs/bifrost/pull/1251#issuecomment-1150984856

Fixes PLT-4880.

## Preview

> Border width set to 1px.

![Screenshot 2022-06-09 at 5 33 58 PM](https://user-images.githubusercontent.com/87924230/172842610-93a070c1-41fa-4602-92fa-77738444cc31.png)

[Deploy preview](https://2db63826.zeal.pages.dev/?path=/story/timeline--timeline-with-custom-border-width)