### PR TITLE
fix: remove horizontal spacing in navbar links slot

### DIFF
--- a/src/components/ZNavBar/ZNavBar.vue
+++ b/src/components/ZNavBar/ZNavBar.vue
@@ -52,7 +52,7 @@ export default {
     },
     linkSlotStyle() {
       return `${this.hideOnScroll}
-              second hidden lg:flex flex-1 items-center justify-center space-x-4 w-full transition-all duration-200 ease-in-out`
+              second hidden lg:flex flex-1 items-center justify-center w-full transition-all duration-200 ease-in-out`
     },
     showMenuButton() {
       return this.$slots.links?.length > 0


### PR DESCRIPTION
The spacing is being reduced to accommodate a greater number of elements in the link slot from an upcoming update:
https://github.com/deepsourcelabs/web-next/pull/530
