### PR TITLE
fix: make watcher for dataSets deeply reactive

### DIFF
--- a/src/components/ZChart/ZChart.vue
+++ b/src/components/ZChart/ZChart.vue
@@ -180,7 +180,7 @@ export default Vue.extend({
       this.updateChart()
     },
     dataSets: {
-      handler: function() {
+      handler: function () {
         this.updateChart()
       },
       deep: true


### PR DESCRIPTION
## Changes

- Make `ZChart.dataSets` watcher deeply reactive.