### PR TITLE
fix: restore icon color logic in `ZMenuItem` to its original way

### DIFF
--- a/src/components/ZMenu/ZMenuItem/ZMenuItem.vue
+++ b/src/components/ZMenu/ZMenuItem/ZMenuItem.vue
@@ -63,7 +63,7 @@ export default Vue.extend({
       if (this.iconColor) {
         return this.iconColor
       }
-      return this.disabled ? 'vanilla-400' : 'vanilla-100'
+      return 'current'
     }
   }
 })


### PR DESCRIPTION
## Changes

- Changes in #488 fixed broken colors in `ZMenuItem` and things started working as per the code, but the existing UI worked with the broken code, so restore behavior to broken style.