### PR TITLE
chore: migration from deepsourcelabs to DeepSourceCorp

### DIFF
--- a/.github/workflows/publish-zeal-pkg.yml
+++ b/.github/workflows/publish-zeal-pkg.yml
@@ -26,8 +26,8 @@ jobs:
         id: import_gpg_sign_commits
         uses: crazy-max/ghaction-import-gpg@v3
         with:
-          gpg-private-key: ${{ secrets.SPOCK_GPG_KEY }}
-          passphrase: ${{ secrets.SPOCK_GPG_KEY_PASSPHRASE }}
+          gpg-private-key: ${{ secrets.DS_BOT_GPG_KEY }}
+          passphrase: ${{ secrets.DS_BOT_GPG_PASSPHRASE }}
           git-user-signingkey: true
           git-commit-gpgsign: true
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Zeal
 
-[![DeepSource](https://deepsource.io/gh/deepsourcelabs/zeal.svg/?label=active+issues&show_trend=true&token=JIW55GPf1_QuPsjkJSkhKBct)](https://deepsource.io/gh/deepsourcelabs/zeal/?ref=repository-badge) [![DeepSource](https://deepsource.io/gh/deepsourcelabs/zeal.svg/?label=resolved+issues&show_trend=true&token=JIW55GPf1_QuPsjkJSkhKBct)](https://deepsource.io/gh/deepsourcelabs/zeal/?ref=repository-badge)
+[![DeepSource](https://app.deepsource.com/gh/DeepSourceCorp/zeal.svg/?label=active+issues&show_trend=true&token=omkRhJZzuS3w0dBXsP_rrwNH)](https://app.deepsource.com/gh/DeepSourceCorp/zeal/?ref=repository-badge)[![DeepSource](https://app.deepsource.com/gh/DeepSourceCorp/zeal.svg/?label=resolved+issues&show_trend=true&token=omkRhJZzuS3w0dBXsP_rrwNH)](https://app.deepsource.com/gh/DeepSourceCorp/zeal/?ref=repository-badge)
 
   <p>Zeal is the component system used across DeepSource Assets</p>
 
@@ -36,7 +36,7 @@ module.exports = {
 
 ### Local setup instructions
 
-1. Clone the Repo using `git clone https://github.com/deepsourcelabs/zeal`
+1. Clone the Repo using `git clone https://github.com/DeepSourceCorp/zeal`
 2. Run `yarn` to install all dependencies
 3. Run `yarn storybook:serve` to run the dev server and storybook for development
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@deepsource/zeal",
   "version": "0.12.37",
-  "repository": "https://github.com/deepsourcelabs/zeal",
+  "repository": "https://github.com/DeepSourceCorp/zeal",
   "license": "BSD-2-Clause",
   "main": "./dist/zeal.common.js",
   "scripts": {

--- a/src/components/ZTab/ZTab.stories.ts
+++ b/src/components/ZTab/ZTab.stories.ts
@@ -50,9 +50,9 @@ export const TabWithLinks = () => ({
   template: `<div class='padded-container'>
                 <div class="gap-5 overflow-auto flex flex-nowrap">
                   <z-tab :isActive="true"><a href="https://deepsource.io">DeepSource</a></z-tab>
-                  <z-tab><a target="blank" href="https://github.com/deepsourcelabs">Github</a></z-tab>
-                  <z-tab><a target="blank" href="https://github.com/deepsourcelabs/zeal">Zeal</a></z-tab>
-                  <z-tab><a target="blank" href="https://github.com/deepsourcelabs/bifrost">Bifrost</a></z-tab>
+                  <z-tab><a target="blank" href="https://github.com/DeepSourceCorp">Github</a></z-tab>
+                  <z-tab><a target="blank" href="https://github.com/DeepSourceCorp/zeal">Zeal</a></z-tab>
+                  <z-tab><a target="blank" href="https://github.com/DeepSourceCorp/bifrost">Bifrost</a></z-tab>
                   <z-tab :disabled="true">Bad Code</z-tab>
                 </div>
       </div>`


### PR DESCRIPTION
Migrating zeal codebase from [github.com/deepsourcelabs](https://github.com/deepsourcelabs) to [github.com/DeepSourceCorp](https://github.com/DeepSourceCorp).
- Update secret variable for pipeline to work.
- Changing the repo name throughout the codebase to DeepSourceCorp.